### PR TITLE
Update NotebookLM compatibility for v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Turn a PDF, arXiv page, or webpage into a NotebookLM notebook and generate artif
 - 로컬 PDF 업로드 지원: 필요 시 파일 선택으로 업로드
 - 아티팩트 설정 제공: Audio/Infographic 등 생성 옵션 조절
 - NotebookLM 최신 요청 형식 지원: 노트북/소스 생성 및 아티팩트 생성 호환성 개선
+- NotebookLM 새 주소(`notebook.google.com`)와 기존 주소를 모두 지원
+- 퀴즈와 플래시카드의 수량 및 난이도를 각각 선택 가능
 - 인포그래픽 레이아웃 프리셋과 NotebookLM 기본 비주얼 스타일을 별도로 선택
 - 감지된 논문 제목을 노트북 제목으로 사용하며, Experience 설정에서 끌 수 있음
 
@@ -30,7 +32,7 @@ Turn a PDF, arXiv page, or webpage into a NotebookLM notebook and generate artif
 6. 확장 목록에서 **Chrome PDF to NotebookLM**이 보이면 설치 완료입니다.
 
 ### 사용 방법
-1. NotebookLM(`https://notebooklm.google.com`)에 Google 계정으로 로그인합니다.
+1. [NotebookLM](https://notebook.google.com)에 Google 계정으로 로그인합니다. 기존 `notebooklm.google.com` 로그인도 계속 지원합니다.
 2. PDF/arXiv/웹페이지를 연 뒤 확장 아이콘을 클릭합니다.
 3. 상황에 맞게 아래 버튼 중 하나를 선택합니다.
 - `Generate Audio Overview` (PDF 감지됨)
@@ -43,7 +45,7 @@ Turn a PDF, arXiv page, or webpage into a NotebookLM notebook and generate artif
 - 권한과 동작은 NotebookLM 및 Chrome 정책 변경에 따라 영향을 받을 수 있습니다.
 
 ### 문제 해결
-- 버튼 동작이 없으면: NotebookLM 로그인 상태를 먼저 확인하세요.
+- 버튼 동작이 없으면: [NotebookLM](https://notebook.google.com)을 열어 로그인 상태를 확인한 뒤 다시 시도하세요. 확장 프로그램은 지원되는 두 주소 중 로그인된 주소를 자동으로 선택합니다.
 - 로컬 PDF 읽기 실패 시: `Allow access to file URLs` 활성화 후 다시 시도하세요.
 - URL 소스 추가 실패 시: `Upload Local PDF` 방식으로 업로드를 시도하세요.
 
@@ -61,6 +63,8 @@ Turn a PDF, arXiv page, or webpage into a NotebookLM notebook and generate artif
 - Local PDF upload support with fallback file picker
 - Artifact settings for Audio/Infographic and more
 - Current NotebookLM request compatibility for notebook, source, and artifact generation
+- Supports both the current `notebook.google.com` address and the legacy address
+- Separate quantity and difficulty controls for quizzes and flashcards
 - Separate infographic layout presets and native NotebookLM visual styles
 - Uses the detected paper title as the notebook title by default, with an opt-out in Experience settings
 
@@ -73,7 +77,7 @@ Turn a PDF, arXiv page, or webpage into a NotebookLM notebook and generate artif
 6. Confirm **Chrome PDF to NotebookLM** appears in your extension list.
 
 ### How to Use
-1. Sign in to NotebookLM at `https://notebooklm.google.com`.
+1. Sign in at [NotebookLM](https://notebook.google.com). Existing sessions at `notebooklm.google.com` remain supported.
 2. Open a PDF/arXiv/webpage and click the extension icon.
 3. Choose the appropriate action:
 - `Generate Audio Overview` (when PDF is detected)
@@ -86,7 +90,7 @@ Turn a PDF, arXiv page, or webpage into a NotebookLM notebook and generate artif
 - Behavior can be affected by NotebookLM and Chrome policy changes.
 
 ### Troubleshooting
-- No progress after start: verify you are logged into NotebookLM.
+- No progress after start: open [NotebookLM](https://notebook.google.com), confirm that you are signed in, and retry. The extension automatically selects a supported address with an active session.
 - Local PDF read fails: enable `Allow access to file URLs` and retry.
 - URL import fails: use `Upload Local PDF` as a fallback.
 

--- a/background.js
+++ b/background.js
@@ -22,6 +22,7 @@
 
 import {
     fetchTokens,
+    getNotebookUrl,
     createNotebook,
     deleteNotebook,
     addUrlSource,
@@ -306,11 +307,13 @@ const DEFAULT_SETTINGS = {
     reportPrompt: '',
     // Quiz
     generateQuiz: false,
-    quizQuantity: 'standard',    // 'fewer'|'standard'
+    quizQuantity: 'standard',    // 'fewer'|'standard'|'more'
     quizDifficulty: 'medium',      // 'easy'|'medium'|'hard'
     quizPrompt: '',
     // Flashcards
     generateFlashcards: false,
+    flashcardsQuantity: 'standard',
+    flashcardsDifficulty: 'medium',
     flashcardsPrompt: '',
     // Infographic
     generateInfographic: true,
@@ -356,7 +359,7 @@ function resolveVideoStyle(s) {
     return map[s] ?? VideoStyle.AUTO_SELECT;
 }
 function resolveQuizQuantity(s) {
-    return { fewer: QuizQuantity.FEWER, standard: QuizQuantity.STANDARD }[s] ?? QuizQuantity.STANDARD;
+    return { fewer: QuizQuantity.FEWER, standard: QuizQuantity.STANDARD, more: QuizQuantity.MORE }[s] ?? QuizQuantity.STANDARD;
 }
 function resolveQuizDifficulty(s) {
     return { easy: QuizDifficulty.EASY, medium: QuizDifficulty.MEDIUM, hard: QuizDifficulty.HARD }[s] ?? QuizDifficulty.MEDIUM;
@@ -708,8 +711,8 @@ async function tickSourcePoll(state) {
                 type: 'flashcards',
                 fn: () => generateFlashcards(
                     state.notebookId, sourceIds,
-                    resolveQuizQuantity(settings.quizQuantity),
-                    resolveQuizDifficulty(settings.quizDifficulty),
+                    resolveQuizQuantity(settings.flashcardsQuantity),
+                    resolveQuizDifficulty(settings.flashcardsDifficulty),
                     settings.flashcardsPrompt || null
                 ),
             },
@@ -893,7 +896,7 @@ async function runPipeline(pdfUrl, pageUrl, uploadFile = null, sourceType = 'pdf
         if (!notebook.id) throw new Error('Failed to create notebook -- no ID returned');
         notebookId = notebook.id;
 
-        const notebookUrl = `https://notebooklm.google.com/notebook/${notebook.id}`;
+        const notebookUrl = getNotebookUrl(notebook.id);
         const sourceStepDetail = uploadFile
             ? `Uploading local PDF: ${uploadFile.filename}`
             : `Adding ${sourceLabel}: ${pdfUrl.substring(0, 60)}...`;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chrome PDF to NotebookLM",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Detect PDF/web sources and generate NotebookLM artifacts from Chrome",
   "permissions": [
     "activeTab",
@@ -13,6 +13,7 @@
     "alarms"
   ],
   "host_permissions": [
+    "https://notebook.google.com/*",
     "https://notebooklm.google.com/*",
     "file:///*",
     "*://*/*"

--- a/notebooklm-api.js
+++ b/notebooklm-api.js
@@ -5,9 +5,18 @@
  * Uses fetch() with credentials from browser cookies.
  */
 
-const BATCHEXECUTE_URL = 'https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute';
-const HOMEPAGE_URL = 'https://notebooklm.google.com/';
-const UPLOAD_URL = 'https://notebooklm.google.com/upload/_/';
+const DEFAULT_BASE_URL = 'https://notebook.google.com';
+const LEGACY_BASE_URL = 'https://notebooklm.google.com';
+const PERSONAL_BASE_URLS = [DEFAULT_BASE_URL, LEGACY_BASE_URL];
+let _baseUrl = DEFAULT_BASE_URL;
+
+function appUrl(path = '/') {
+  return `${_baseUrl}${path}`;
+}
+
+function getNotebookUrl(notebookId) {
+  return appUrl(`/notebook/${notebookId}`);
+}
 
 // RPC Method IDs (reverse-engineered from notebooklm-py rpc/types.py)
 const RPCMethod = {
@@ -74,6 +83,7 @@ const VideoStyle = {
 const QuizQuantity = {
   FEWER: 1,
   STANDARD: 2,
+  MORE: 3,
 };
 
 // Quiz/flashcard difficulty options
@@ -134,10 +144,13 @@ const InfographicStyle = {
 
 // Artifact status codes
 const ArtifactStatus = {
-  PROCESSING: 1,
-  PENDING: 2,
+  UNKNOWN: 0,
+  PENDING: 1,
+  PROCESSING: 2,
   COMPLETED: 3,
   FAILED: 4,
+  SUGGESTED: 5,
+  PENDING_REVIEW: 6,
 };
 
 // Source status codes
@@ -188,38 +201,53 @@ function artifactClientOptions() {
  * Since we're in a Chrome extension, browser cookies are sent automatically.
  */
 async function fetchTokens() {
-  const response = await fetch(HOMEPAGE_URL, {
-    credentials: 'include',
-    redirect: 'follow',
-  });
+  const candidates = [_baseUrl, ...PERSONAL_BASE_URLS.filter(url => url !== _baseUrl)];
+  const failures = [];
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch NotebookLM homepage: ${response.status}`);
-  }
+  for (const baseUrl of candidates) {
+    const homepageUrl = `${baseUrl}/`;
+    try {
+      const response = await fetch(homepageUrl, {
+        credentials: 'include',
+        redirect: 'follow',
+      });
 
-  const html = await response.text();
+      if (!response.ok) {
+        failures.push(`${baseUrl} returned HTTP ${response.status}`);
+        continue;
+      }
 
-  // Extract CSRF token: "SNlM0e":"<token>"
-  const csrfMatch = html.match(/"SNlM0e"\s*:\s*"([^"]+)"/);
-  if (!csrfMatch) {
-    // Check if redirected to login
-    if (response.url.includes('accounts.google.com')) {
-      throw new Error('AUTH_REQUIRED: Not logged in to Google. Please sign in to NotebookLM first.');
+      const responseHost = new URL(response.url || homepageUrl).hostname;
+      const allowedHosts = PERSONAL_BASE_URLS.map(url => new URL(url).hostname);
+      if (!allowedHosts.includes(responseHost)) {
+        failures.push(`${baseUrl} redirected to ${responseHost}`);
+        continue;
+      }
+
+      const html = await response.text();
+      const csrfMatch = html.match(/"SNlM0e"\s*:\s*"([^"]+)"/);
+      const sessionMatch = html.match(/"FdrFJe"\s*:\s*"([^"]+)"/);
+      if (!csrfMatch || !sessionMatch) {
+        failures.push(`${baseUrl} did not provide an authenticated NotebookLM session`);
+        continue;
+      }
+
+      _baseUrl = PERSONAL_BASE_URLS.find(
+        url => new URL(url).hostname === responseHost
+      ) || baseUrl;
+      _csrfToken = csrfMatch[1];
+      _sessionId = sessionMatch[1];
+
+      console.log(`[NotebookLM API] Tokens fetched successfully from ${responseHost}`);
+      return { csrfToken: _csrfToken, sessionId: _sessionId };
+    } catch (error) {
+      failures.push(`${baseUrl} failed: ${error?.message || 'request failed'}`);
     }
-    throw new Error('CSRF token (SNlM0e) not found in NotebookLM page. Auth may be expired.');
   }
 
-  // Extract session ID: "FdrFJe":"<session_id>"
-  const sessionMatch = html.match(/"FdrFJe"\s*:\s*"([^"]+)"/);
-  if (!sessionMatch) {
-    throw new Error('Session ID (FdrFJe) not found in NotebookLM page.');
-  }
-
-  _csrfToken = csrfMatch[1];
-  _sessionId = sessionMatch[1];
-
-  console.log('[NotebookLM API] Tokens fetched successfully');
-  return { csrfToken: _csrfToken, sessionId: _sessionId };
+  throw new Error(
+    `AUTH_REQUIRED: Could not find an authenticated NotebookLM session. Sign in at ${DEFAULT_BASE_URL} and retry. ${failures.join('. ')}`
+  );
 }
 
 async function ensureTokens() {
@@ -471,7 +499,7 @@ async function rpcCall(methodId, params, sourcePath = '/', allowNull = false) {
     const rpcRequest = encodeRpcRequest(methodId, params);
     const body = buildRequestBody(rpcRequest, csrfToken);
     const urlParams = buildUrlParams(methodId, sourcePath, sessionId);
-    const url = `${BATCHEXECUTE_URL}?${urlParams.toString()}`;
+    const url = `${appUrl('/_/LabsTailwindUi/data/batchexecute')}?${urlParams.toString()}`;
 
     let response;
     let responseText;
@@ -666,7 +694,7 @@ async function registerFileSource(notebookId, filename) {
 }
 
 async function startResumableUpload(notebookId, filename, fileSize, sourceId, mimeType) {
-  const response = await fetch(`${UPLOAD_URL}?authuser=0`, {
+  const response = await fetch(`${appUrl('/upload/_/')}?authuser=0`, {
     method: 'POST',
     credentials: 'include',
     headers: {
@@ -743,6 +771,12 @@ async function addFileSource(notebookId, filename, fileData, mimeType = 'applica
  * Returns { id, title }
  */
 async function addUrlSource(notebookId, url) {
+  // Capture the existing source IDs before creating anything. URL values are
+  // not unique within a notebook, so an uncertainty probe must never adopt an
+  // older source that happens to use the same URL.
+  const baselineSourceIds = new Set(
+    (await listSources(notebookId)).map(source => String(source.id))
+  );
   const params = [
     [[null, null, [url], null, null, null, null, null, null, null, 1]],
     notebookId,
@@ -764,14 +798,25 @@ async function addUrlSource(notebookId, url) {
     try {
       for (let probeAttempt = 0; probeAttempt < 3; probeAttempt++) {
         const sources = await listSources(notebookId);
-        const committedSource = sources.find(source => source.url === url || source.title === url);
-        if (committedSource) {
+        const committedMatches = sources.filter(source =>
+          !baselineSourceIds.has(String(source.id))
+          && (source.url === url || source.title === url)
+        );
+        if (committedMatches.length === 1) {
           console.warn('[NotebookLM API] Source mutation response was incomplete; recovered the committed source.');
-          return committedSource;
+          return committedMatches[0];
+        }
+        if (committedMatches.length > 1) {
+          const ambiguous = new Error(
+            'SOURCE_RECOVERY_AMBIGUOUS: More than one new matching source appeared. Check the notebook before retrying.'
+          );
+          ambiguous.code = 'SOURCE_RECOVERY_AMBIGUOUS';
+          throw ambiguous;
         }
         if (probeAttempt < 2) await _retrySleep(2000);
       }
     } catch (probeError) {
+      if (probeError?.code === 'SOURCE_RECOVERY_AMBIGUOUS') throw probeError;
       console.warn('[NotebookLM API] Could not reconcile the uncertain source mutation:', probeError.message);
     }
 
@@ -1236,8 +1281,8 @@ async function generateFlashcards(notebookId, sourceIds = null, quantity = QuizQ
           null,
           null,
           [
-            difficulty || null,
-            quantity || null,
+            quantity || QuizQuantity.STANDARD,
+            difficulty || QuizDifficulty.MEDIUM,
           ],
         ],
       ],
@@ -1527,6 +1572,12 @@ function parseGenerationResult(result) {
     case ArtifactStatus.FAILED:
       status = 'failed';
       break;
+    case ArtifactStatus.SUGGESTED:
+      status = 'suggested';
+      break;
+    case ArtifactStatus.PENDING_REVIEW:
+      status = 'pending_review';
+      break;
     default:
       status = 'in_progress';
   }
@@ -1615,6 +1666,8 @@ async function listArtifactStatuses(notebookId) {
         status = isMediaArtifactReady(art, typeCode) ? 'completed' : 'in_progress';
         break;
       case ArtifactStatus.FAILED: status = 'failed'; break;
+      case ArtifactStatus.SUGGESTED: status = 'suggested'; break;
+      case ArtifactStatus.PENDING_REVIEW: status = 'pending_review'; break;
       default: status = 'unknown';
     }
 
@@ -1716,6 +1769,7 @@ async function getNotebookTitle(notebookId) {
 export {
   fetchTokens,
   ensureTokens,
+  getNotebookUrl,
   createNotebook,
   deleteNotebook,
   addUrlSource,
@@ -1761,6 +1815,10 @@ export const __testing = {
   resetTokens() {
     _csrfToken = null;
     _sessionId = null;
+    _baseUrl = DEFAULT_BASE_URL;
+  },
+  getBaseUrl() {
+    return _baseUrl;
   },
   setRetrySleep(fn) {
     _retrySleep = typeof fn === 'function' ? fn : sleep;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-pdf-to-notebooklm",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/popup.html
+++ b/popup.html
@@ -783,6 +783,8 @@
                 for="qq-fewer">Fewer</label>
               <input class="s-radio-option" type="radio" name="quizQuantity" id="qq-standard" value="standard"><label
                 for="qq-standard">Standard</label>
+              <input class="s-radio-option" type="radio" name="quizQuantity" id="qq-more" value="more"><label
+                for="qq-more">More</label>
             </div>
           </div>
           <div class="s-field">
@@ -815,6 +817,28 @@
           <span class="s-section-arrow">▸</span>
         </div>
         <div class="s-section-content">
+          <div class="s-field">
+            <span class="s-label">Quantity</span>
+            <div class="s-radio-group">
+              <input class="s-radio-option" type="radio" name="flashcardsQuantity" id="fq-fewer" value="fewer"><label
+                for="fq-fewer">Fewer</label>
+              <input class="s-radio-option" type="radio" name="flashcardsQuantity" id="fq-standard" value="standard"><label
+                for="fq-standard">Standard</label>
+              <input class="s-radio-option" type="radio" name="flashcardsQuantity" id="fq-more" value="more"><label
+                for="fq-more">More</label>
+            </div>
+          </div>
+          <div class="s-field">
+            <span class="s-label">Difficulty</span>
+            <div class="s-radio-group">
+              <input class="s-radio-option" type="radio" name="flashcardsDifficulty" id="fd-easy" value="easy"><label
+                for="fd-easy">Easy</label>
+              <input class="s-radio-option" type="radio" name="flashcardsDifficulty" id="fd-med" value="medium"><label
+                for="fd-med">Medium</label>
+              <input class="s-radio-option" type="radio" name="flashcardsDifficulty" id="fd-hard" value="hard"><label
+                for="fd-hard">Hard</label>
+            </div>
+          </div>
           <div class="s-field">
             <span class="s-label">Custom instructions</span>
             <textarea id="s-flashcardsPrompt" class="s-textarea"

--- a/popup.js
+++ b/popup.js
@@ -29,7 +29,7 @@ const DEFAULTS = {
     generateVideo: false, videoFormat: 'explainer', videoStyle: 'auto', videoPrompt: '', videoStylePrompt: '',
     generateReport: false, reportFormat: 'study_guide', reportPrompt: '',
     generateQuiz: false, quizQuantity: 'standard', quizDifficulty: 'medium', quizPrompt: '',
-    generateFlashcards: false, flashcardsPrompt: '',
+    generateFlashcards: false, flashcardsQuantity: 'standard', flashcardsDifficulty: 'medium', flashcardsPrompt: '',
     generateInfographic: true,
     infographicOrientation: 'landscape', infographicDetail: 'standard', infographicStylePreset: 'auto', infographicNativeStyle: 'auto', infographicPrompt: '',
     generateSlideDeck: false, slideDeckFormat: 'detailed_deck', slideDeckLength: 'default', slideDeckPrompt: '',
@@ -49,6 +49,7 @@ const SELECT_MAP = {
 const RADIO_NAMES = [
     'audioLength', 'videoFormat', 'reportFormat',
     'quizQuantity', 'quizDifficulty',
+    'flashcardsQuantity', 'flashcardsDifficulty',
     'infographicOrientation', 'infographicDetail',
     'slideDeckFormat', 'slideDeckLength',
 ];

--- a/tests/notebooklm-api.test.js
+++ b/tests/notebooklm-api.test.js
@@ -5,7 +5,9 @@ import {
   __testing,
   addFileSource,
   addUrlSource,
+  ArtifactStatus,
   createNotebook,
+  fetchTokens,
   generateAudio,
   generateDataTable,
   generateFlashcards,
@@ -14,11 +16,14 @@ import {
   generateReport,
   generateSlideDeck,
   generateVideo,
+  getNotebookUrl,
   InfographicDetail,
   InfographicOrientation,
   InfographicStyle,
   listArtifactStatuses,
   listSources,
+  QuizDifficulty,
+  QuizQuantity,
   VideoFormat,
   VideoStyle,
 } from '../notebooklm-api.js';
@@ -38,8 +43,8 @@ function mockResponse({ status = 200, body = '', headers = {}, url = 'https://no
   };
 }
 
-function tokenResponse(token = 'csrf-token') {
-  return mockResponse({ body: `"SNlM0e":"${token}","FdrFJe":"session-id"` });
+function tokenResponse(token = 'csrf-token', url = 'https://notebook.google.com/') {
+  return mockResponse({ body: `"SNlM0e":"${token}","FdrFJe":"session-id"`, url });
 }
 
 function rpcResponse(methodId, result) {
@@ -51,6 +56,10 @@ function decodeRpcParams(options) {
   const body = new URLSearchParams(options.body);
   const request = JSON.parse(body.get('f.req'));
   return JSON.parse(request[0][0][1]);
+}
+
+function sourceRow(id, url) {
+  return [[id], url, [null, null, null, null, null, null, null, [url]], [null, 2]];
 }
 
 function installFetch(handler) {
@@ -117,6 +126,58 @@ test('visual style enums match the current NotebookLM wire values', () => {
   });
 });
 
+test('artifact status and quiz quantity enums match current wire values', () => {
+  assert.deepEqual(ArtifactStatus, {
+    UNKNOWN: 0,
+    PENDING: 1,
+    PROCESSING: 2,
+    COMPLETED: 3,
+    FAILED: 4,
+    SUGGESTED: 5,
+    PENDING_REVIEW: 6,
+  });
+  assert.deepEqual(QuizQuantity, {
+    FEWER: 1,
+    STANDARD: 2,
+    MORE: 3,
+  });
+});
+
+test('authentication prefers the renamed NotebookLM host', async () => {
+  const calls = installFetch(url => {
+    assert.equal(url, 'https://notebook.google.com/');
+    return tokenResponse('new-host-token', url);
+  });
+
+  await fetchTokens();
+  assert.equal(calls.length, 1);
+  assert.equal(__testing.getBaseUrl(), 'https://notebook.google.com');
+  assert.equal(getNotebookUrl('notebook-id'), 'https://notebook.google.com/notebook/notebook-id');
+});
+
+test('authentication falls back to the supported legacy host', async () => {
+  const calls = installFetch(url => {
+    if (url === 'https://notebook.google.com/') {
+      return mockResponse({
+        body: TOKEN_HTML,
+        url: 'https://accounts.google.com/ServiceLogin',
+      });
+    }
+    if (url === 'https://notebooklm.google.com/') {
+      return tokenResponse('legacy-host-token', url);
+    }
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  await fetchTokens();
+  assert.deepEqual(calls.map(call => call.url), [
+    'https://notebook.google.com/',
+    'https://notebooklm.google.com/',
+  ]);
+  assert.equal(__testing.getBaseUrl(), 'https://notebooklm.google.com');
+  assert.equal(getNotebookUrl('notebook-id'), 'https://notebooklm.google.com/notebook/notebook-id');
+});
+
 test('notebook creation uses the migrated template block', async () => {
   let params;
   installFetch((url, options) => {
@@ -134,6 +195,10 @@ test('URL source addition uses the migrated source spec and template block', asy
   let params;
   installFetch((url, options) => {
     if (url.endsWith('/')) return tokenResponse();
+    const methodId = new URL(url).searchParams.get('rpcids');
+    if (methodId === __testing.RPCMethod.GET_NOTEBOOK) {
+      return rpcResponse(__testing.RPCMethod.GET_NOTEBOOK, [[null, []]]);
+    }
     params = decodeRpcParams(options);
     return rpcResponse(__testing.RPCMethod.ADD_SOURCE, [['source-id-12345']]);
   });
@@ -181,17 +246,107 @@ test('URL source addition reconciles a committed mutation after its response sta
   assert.equal(probeCount, 2);
 });
 
+test('URL source recovery ignores a matching source that predates the mutation', async () => {
+  const sourceUrl = 'https://example.com/repeated-source';
+  __testing.setMutationTimeout(1);
+  let getNotebookCalls = 0;
+  let addSourceCalls = 0;
+
+  installFetch((url) => {
+    if (url.endsWith('/')) return tokenResponse();
+    const methodId = new URL(url).searchParams.get('rpcids');
+    if (methodId === __testing.RPCMethod.GET_NOTEBOOK) {
+      getNotebookCalls++;
+      const oldSource = sourceRow('source-id-old', sourceUrl);
+      const sources = [oldSource];
+      if (getNotebookCalls > 1) {
+        sources.push(sourceRow('source-id-new', sourceUrl));
+      }
+      return rpcResponse(__testing.RPCMethod.GET_NOTEBOOK, [[null, sources]]);
+    }
+    if (methodId === __testing.RPCMethod.ADD_SOURCE) {
+      addSourceCalls++;
+      const response = mockResponse();
+      response.text = async () => new Promise(() => {});
+      return response;
+    }
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  const source = await addUrlSource('notebook-id-12345', sourceUrl);
+  assert.equal(source.id, 'source-id-new');
+  assert.equal(addSourceCalls, 1);
+  assert.equal(getNotebookCalls, 2);
+});
+
+test('URL source recovery does not report an older match as newly created', async () => {
+  const sourceUrl = 'https://example.com/existing-only';
+  let getNotebookCalls = 0;
+  let addSourceCalls = 0;
+
+  installFetch(url => {
+    if (url.endsWith('/')) return tokenResponse();
+    const methodId = new URL(url).searchParams.get('rpcids');
+    if (methodId === __testing.RPCMethod.GET_NOTEBOOK) {
+      getNotebookCalls++;
+      return rpcResponse(
+        __testing.RPCMethod.GET_NOTEBOOK,
+        [[null, [sourceRow('source-id-old', sourceUrl)]]]
+      );
+    }
+    if (methodId === __testing.RPCMethod.ADD_SOURCE) {
+      addSourceCalls++;
+      return mockResponse({ status: 503 });
+    }
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  await assert.rejects(
+    () => addUrlSource('notebook-id-12345', sourceUrl),
+    error => error.code === 'TRANSIENT_MUTATION_UNCERTAIN'
+  );
+  assert.equal(addSourceCalls, 1);
+  assert.equal(getNotebookCalls, 4);
+});
+
+test('URL source recovery refuses an ambiguous set of new matches', async () => {
+  const sourceUrl = 'https://example.com/ambiguous';
+  let getNotebookCalls = 0;
+
+  installFetch(url => {
+    if (url.endsWith('/')) return tokenResponse();
+    const methodId = new URL(url).searchParams.get('rpcids');
+    if (methodId === __testing.RPCMethod.GET_NOTEBOOK) {
+      getNotebookCalls++;
+      const sources = getNotebookCalls === 1
+        ? []
+        : [sourceRow('source-id-one', sourceUrl), sourceRow('source-id-two', sourceUrl)];
+      return rpcResponse(__testing.RPCMethod.GET_NOTEBOOK, [[null, sources]]);
+    }
+    if (methodId === __testing.RPCMethod.ADD_SOURCE) {
+      return mockResponse({ status: 503 });
+    }
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  await assert.rejects(
+    () => addUrlSource('notebook-id-12345', sourceUrl),
+    error => error.code === 'SOURCE_RECOVERY_AMBIGUOUS'
+  );
+  assert.equal(getNotebookCalls, 2);
+});
+
 test('file upload registers with the migrated block and sends the MIME type', async () => {
   let registerParams;
   let uploadStartHeaders;
   let finalized = false;
   installFetch((url, options) => {
-    if (url === 'https://notebooklm.google.com/') return tokenResponse();
+    if (url === 'https://notebook.google.com/') return tokenResponse();
     if (url.includes('batchexecute')) {
       registerParams = decodeRpcParams(options);
       return rpcResponse(__testing.RPCMethod.ADD_SOURCE_FILE, [['source-id-12345']]);
     }
-    if (url.startsWith('https://notebooklm.google.com/upload/_/')) {
+    if (url.startsWith('https://notebook.google.com/upload/_/')) {
       uploadStartHeaders = options.headers;
       return mockResponse({ headers: { 'x-goog-upload-url': 'https://upload.example/finalize' } });
     }
@@ -235,6 +390,27 @@ test('all CREATE_ARTIFACT builders use the full capability envelope', async () =
   for (const params of captured) {
     assert.deepEqual(params[0], __testing.artifactClientOptions());
   }
+});
+
+test('quiz and flashcard options serialize as quantity then difficulty', async () => {
+  const captured = [];
+  installFetch((url, options) => {
+    if (url.endsWith('/')) return tokenResponse();
+    captured.push(decodeRpcParams(options));
+    return rpcResponse(__testing.RPCMethod.CREATE_ARTIFACT, [['artifact-id-12345']]);
+  });
+
+  await generateQuiz(
+    'notebook-id-12345', ['source-id-12345'],
+    QuizQuantity.MORE, QuizDifficulty.HARD
+  );
+  await generateFlashcards(
+    'notebook-id-12345', ['source-id-12345'],
+    QuizQuantity.FEWER, QuizDifficulty.HARD
+  );
+
+  assert.deepEqual(captured[0][2][9][1][7], [3, 3]);
+  assert.deepEqual(captured[1][2][9][1][6], [1, 3]);
 });
 
 test('video styles use corrected wire values and custom prompt serialization', async () => {
@@ -390,4 +566,22 @@ test('completed media waits for its URL before reporting completion', async () =
   const ready = await listArtifactStatuses('notebook-id-12345');
   assert.equal(settling.get('artifact-id-12345').status, 'in_progress');
   assert.equal(ready.get('artifact-id-12345').status, 'completed');
+});
+
+test('artifact status 1 is pending and status 2 is processing', async () => {
+  let rpcAttempts = 0;
+  installFetch(url => {
+    if (url.endsWith('/')) return tokenResponse();
+    rpcAttempts++;
+    const artifact = [];
+    artifact[0] = 'artifact-id-12345';
+    artifact[2] = 2;
+    artifact[4] = rpcAttempts;
+    return rpcResponse(__testing.RPCMethod.LIST_ARTIFACTS, [[artifact]]);
+  });
+
+  const pending = await listArtifactStatuses('notebook-id-12345');
+  const processing = await listArtifactStatuses('notebook-id-12345');
+  assert.equal(pending.get('artifact-id-12345').status, 'pending');
+  assert.equal(processing.get('artifact-id-12345').status, 'in_progress');
 });


### PR DESCRIPTION
## What changed

- Prefer the current `notebook.google.com` address while retaining the supported legacy address as an automatic fallback.
- Snapshot source IDs before URL creation so an uncertain response cannot adopt an older matching source.
- Correct quiz and flashcard option serialization and add the supported More quantity.
- Give flashcards their own quantity and difficulty controls.
- Correct artifact lifecycle status values and document the current sign-in behavior in Korean and English.

## Why

Recent `notebooklm-py` wire-contract updates identified a renamed personal host, transposed artifact status values, reversed flashcard options, and a duplicate-recovery edge case for repeated URLs. This release brings the extension into alignment while preserving compatibility for existing users.

## User impact

Existing installations can continue using their current NotebookLM session. Quiz and flashcard choices now reach NotebookLM as selected, and interrupted URL imports will no longer silently claim an older matching source.

## Validation

- 24 deterministic Node tests passed.
- JavaScript syntax checks passed for the API, background worker, and popup.
- Manifest and package versions were verified as `1.1.1`.
- JSON and diff checks passed.
- The expanded popup was rendered at 420 px with no horizontal overflow.
