### PR TITLE
Harden ScholarRelay v1.2.1 release paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         id: setup-chrome
         uses: browser-actions/setup-chrome@48ad923757ca74d66703209fe939badbdf80f2f4 # v2.2.0
         with:
-          chrome-version: latest
+          chrome-version: stable
 
       - name: Run deterministic tests
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-and-package:
-    runs-on: windows-latest
-    timeout-minutes: 15
+  chrome-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Check out
@@ -34,13 +34,27 @@ jobs:
         with:
           chrome-version: stable
 
-      - name: Run deterministic tests
-        run: npm test
-
       - name: Run Chrome smoke test
-        run: npm run smoke:chrome
+        run: xvfb-run --auto-servernum npm run smoke:chrome
         env:
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+
+  test-and-package:
+    runs-on: windows-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Run deterministic tests
+        run: npm test
 
       - name: Check syntax, JSON, and whitespace
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,156 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-and-package:
+    runs-on: windows-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Run deterministic tests
+        run: npm test
+
+      - name: Run Chrome smoke test
+        run: npm run smoke:chrome
+
+      - name: Check syntax, JSON, and whitespace
+        shell: pwsh
+        run: |
+          $files = Get-ChildItem -Recurse -File -Include '*.js', '*.mjs' |
+            Where-Object { $_.FullName -notmatch '[\\/]dist[\\/]' }
+          foreach ($file in $files) {
+            node --check $file.FullName
+            if ($LASTEXITCODE -ne 0) {
+              throw "Syntax check failed: $($file.FullName)"
+            }
+          }
+          Get-ChildItem -Recurse -File -Filter '*.json' | ForEach-Object {
+            Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json | Out-Null
+          }
+          git diff --check
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Whitespace check failed'
+          }
+
+      - name: Build and verify release package
+        shell: pwsh
+        run: |
+          npm run package:store
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Package build failed'
+          }
+
+          $manifest = Get-Content manifest.json -Raw | ConvertFrom-Json
+          $zipPath = "dist/scholar-relay-v$($manifest.version).zip"
+          $checksumPath = "$zipPath.sha256"
+          if (-not (Test-Path -LiteralPath $zipPath -PathType Leaf)) {
+            throw "Missing package: $zipPath"
+          }
+          if (-not (Test-Path -LiteralPath $checksumPath -PathType Leaf)) {
+            throw "Missing checksum: $checksumPath"
+          }
+
+          $expected = @(
+            '_locales/en/messages.json',
+            '_locales/ko/messages.json',
+            'background.js',
+            'content.js',
+            'detection-policy.js',
+            'icons/icon16.png',
+            'icons/icon48.png',
+            'icons/icon128.png',
+            'LICENSE',
+            'manifest.json',
+            'notebooklm-api.js',
+            'offscreen.html',
+            'offscreen.js',
+            'pdf-file-policy.js',
+            'pdf-metadata.js',
+            'popup.html',
+            'popup.js',
+            'runtime-policy.js',
+            'site-permissions.js'
+          ) | Sort-Object
+
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $archive = [IO.Compression.ZipFile]::OpenRead($zipPath)
+          try {
+            $entries = @($archive.Entries | Where-Object { -not [string]::IsNullOrEmpty($_.Name) })
+            $actual = @($entries.FullName | ForEach-Object { $_ -replace '\\', '/' }) | Sort-Object
+            if (Compare-Object $expected $actual) {
+              throw 'Archive allowlist mismatch'
+            }
+
+            $manifestEntry = $entries | Where-Object FullName -eq 'manifest.json'
+            $reader = [IO.StreamReader]::new($manifestEntry.Open())
+            try {
+              $embedded = $reader.ReadToEnd() | ConvertFrom-Json
+            }
+            finally {
+              $reader.Dispose()
+            }
+            if ($embedded.version -ne $manifest.version) {
+              throw 'Embedded manifest version mismatch'
+            }
+          }
+          finally {
+            $archive.Dispose()
+          }
+
+          function Get-Sha256([string]$Path) {
+            $sha256 = [Security.Cryptography.SHA256]::Create()
+            $stream = [IO.File]::OpenRead($Path)
+            try {
+              $bytes = $sha256.ComputeHash($stream)
+            }
+            finally {
+              $stream.Dispose()
+              $sha256.Dispose()
+            }
+            return [BitConverter]::ToString($bytes).Replace('-', '').ToLowerInvariant()
+          }
+
+          $actualHash = Get-Sha256 $zipPath
+          $expectedChecksum = "$actualHash  $([IO.Path]::GetFileName($zipPath))`n"
+          $actualChecksum = [IO.File]::ReadAllText($checksumPath)
+          if ($actualChecksum -cne $expectedChecksum) {
+            throw 'Package checksum mismatch'
+          }
+
+          $extractPath = Join-Path $env:RUNNER_TEMP "scholar-relay-$([guid]::NewGuid().ToString('N'))"
+          try {
+            [IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $extractPath)
+            foreach ($relativePath in $expected) {
+              $sourcePath = Join-Path (Get-Location) ($relativePath -replace '/', '\\')
+              $archivedPath = Join-Path $extractPath ($relativePath -replace '/', '\\')
+              if ((Get-Sha256 $sourcePath) -ne (Get-Sha256 $archivedPath)) {
+                throw "Archive content differs from checkout: $relativePath"
+              }
+            }
+          }
+          finally {
+            if (Test-Path -LiteralPath $extractPath) {
+              [IO.Directory]::Delete($extractPath, $true)
+            }
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,19 @@ jobs:
           node-version: "24"
           package-manager-cache: false
 
+      - name: Set up Chrome for Testing
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@48ad923757ca74d66703209fe939badbdf80f2f4 # v2.2.0
+        with:
+          chrome-version: latest
+
       - name: Run deterministic tests
         run: npm test
 
       - name: Run Chrome smoke test
         run: npm run smoke:chrome
+        env:
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
 
       - name: Check syntax, JSON, and whitespace
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+icons/~syncthing~*.tmp

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ ScholarRelay는 PDF, 연구 논문 또는 웹페이지를 Gemini Notebook(이전
 - 실행되지 않으면 [Gemini Notebook](https://notebook.google.com)에 로그인되어 있는지 확인하고 다시 시도합니다.
 - 컬렉션이 보이지 않으면 Gemini Notebook에서 컬렉션을 만든 뒤 설정의 새로고침 버튼을 클릭합니다.
 - URL 소스를 추가하지 못하면 **Upload Local PDF**로 파일을 직접 업로드합니다.
+- Chrome 메모리를 안전하게 유지하기 위해 직접 내려받기 및 로컬 업로드는 32 MiB로 제한됩니다. 더 큰 원격 PDF는 URL 가져오기를 사용하고, 더 큰 로컬 파일은 Gemini Notebook에서 직접 업로드합니다.
 
 ---
 
@@ -113,6 +114,7 @@ Source processing and artifact generation continue if collection assignment fail
 - If a run does not start, confirm that you are signed in at [Gemini Notebook](https://notebook.google.com) and retry.
 - If a collection is missing, create it in Gemini Notebook and use the refresh button in Settings.
 - If a URL source cannot be added, use **Upload Local PDF** to upload the file directly.
+- Direct downloads and local uploads are limited to 32 MiB to keep Chrome memory use safe. Larger remote PDFs use URL import, while larger local files should be uploaded directly in Gemini Notebook.
 
 ## Credits and compatibility
 
@@ -126,4 +128,4 @@ MIT. See [LICENSE](./LICENSE).
 
 ## Maintainer: store package
 
-Run `npm run package:store` to create the allowlisted Chrome Web Store upload ZIP in `dist/`. Store copy, privacy declarations, reviewer instructions, and required asset paths are maintained in [`docs/chrome-web-store-listing.md`](./docs/chrome-web-store-listing.md).
+Run `npm run package:store` to create the canonical allowlisted ZIP and SHA-256 sidecar in `dist/`. The same ZIP is used for GitHub releases and Chrome Web Store upload. Store copy, privacy declarations, reviewer instructions, and required asset paths are maintained in [`docs/chrome-web-store-listing.md`](./docs/chrome-web-store-listing.md).

--- a/background.js
+++ b/background.js
@@ -58,11 +58,23 @@ import {
 import {
     PIPELINE_ALARM_NAME,
     PIPELINE_POLL_PERIOD_MINUTES,
+    canStopPipeline,
     createExclusiveRunner,
+    createPipelineStateCoordinator,
     interruptedPipelineUpdate,
+    isActivePipelineRun,
     pollingElapsedMs,
     runtimeRecoveryAction,
 } from './runtime-policy.js';
+import { bindDetectionToTab } from './detection-policy.js';
+import {
+    MAX_PDF_UPLOAD_BYTES,
+    assertPdfUploadSize,
+    decodedBase64ByteLength,
+    hasBase64PdfSignature,
+    hasPdfSignature,
+    readResponseWithinLimit,
+} from './pdf-file-policy.js';
 import { httpOriginPattern, sameHttpOrigin } from './site-permissions.js';
 
 const ALARM_NAME = PIPELINE_ALARM_NAME;
@@ -74,6 +86,7 @@ const ARTIFACT_START_DELAY_MS = 1000;
 
 const INITIAL_STATE = {
     status: 'idle',          // idle | running | completed | error
+    runId: null,
     step: null,              // current step name
     stepDetail: '',          // human-readable detail for current step
     pdfUrl: null,
@@ -97,28 +110,39 @@ async function getState() {
     return result.pipelineState || { ...INITIAL_STATE };
 }
 
-let stateMutationQueue = Promise.resolve();
+const pipelineState = createPipelineStateCoordinator({
+    readState: getState,
+    writeState: state => chrome.storage.local.set({ pipelineState: state }),
+});
 
 async function setState(updates) {
-    const applyUpdate = async () => {
-        const current = await getState();
-        const resolved = typeof updates === 'function' ? updates(current) : updates;
-        const newState = { ...current, ...resolved };
-        await chrome.storage.local.set({ pipelineState: newState });
-        return newState;
-    };
-    stateMutationQueue = stateMutationQueue.then(applyUpdate, applyUpdate);
-    return stateMutationQueue;
+    return (await pipelineState.update(updates)).state;
 }
 
-async function resetState() {
-    const applyReset = async () => {
-        const reset = { ...INITIAL_STATE };
-        await chrome.storage.local.set({ pipelineState: reset });
-        return reset;
-    };
-    stateMutationQueue = stateMutationQueue.then(applyReset, applyReset);
-    return stateMutationQueue;
+async function resetState(options = {}) {
+    const result = await pipelineState.reset({ ...INITIAL_STATE }, options);
+    return result.applied ? result.state : null;
+}
+
+async function transitionRun(runId, updates, options = {}) {
+    const result = await pipelineState.transition(runId, updates, options);
+    if (result.effectError) throw result.effectError;
+    return result.applied ? result.state : null;
+}
+
+async function requireActiveRun(runId, expectedSteps = null) {
+    const state = await getState();
+    if (!isActivePipelineRun(state, runId)) {
+        const error = new Error('Pipeline run is no longer active');
+        error.code = 'PIPELINE_STALE_RUN';
+        throw error;
+    }
+    if (expectedSteps && !expectedSteps.includes(state.step)) {
+        const error = new Error(`Pipeline step changed from ${expectedSteps.join(' or ')} to ${state.step || 'none'}`);
+        error.code = 'PIPELINE_STALE_RUN';
+        throw error;
+    }
+    return state;
 }
 
 function isWebpageSourceType(sourceType) {
@@ -276,16 +300,13 @@ async function downloadRemotePdfForUpload(pdfUrl, pageUrl = null) {
     const likelyPdfMime = /application\/pdf/i.test(contentType) || /application\/octet-stream/i.test(contentType);
     const likelyPdfUrl = /\.pdf(\?|#|$)/i.test(response.url || pdfUrl);
 
-    const fileData = await response.arrayBuffer();
-    const bytes = new Uint8Array(fileData);
-    const hasPdfMagic = bytes.length >= 4 &&
-        bytes[0] === 0x25 && // %
-        bytes[1] === 0x50 && // P
-        bytes[2] === 0x44 && // D
-        bytes[3] === 0x46;   // F
+    const bytes = await readResponseWithinLimit(response);
+    const fileData = bytes.buffer;
+    const hasPdfMagic = hasPdfSignature(bytes);
 
-    if (!likelyPdfMime && !likelyPdfUrl && !hasPdfMagic) {
-        throw new Error('Downloaded content does not appear to be a PDF');
+    if (!hasPdfMagic) {
+        const deliveryHint = likelyPdfMime || likelyPdfUrl ? ' despite its PDF URL or content type' : '';
+        throw new Error(`Downloaded content does not contain a PDF signature${deliveryHint}`);
     }
 
     return {
@@ -300,12 +321,14 @@ async function downloadRemotePdfForUpload(pdfUrl, pageUrl = null) {
 // =========================================================================
 
 function setBadge(text, color) {
-    chrome.action.setBadgeText({ text });
-    chrome.action.setBadgeBackgroundColor({ color });
+    return Promise.all([
+        chrome.action.setBadgeText({ text }),
+        chrome.action.setBadgeBackgroundColor({ color }),
+    ]);
 }
 
 function clearBadge() {
-    chrome.action.setBadgeText({ text: '' });
+    return chrome.action.setBadgeText({ text: '' });
 }
 
 // =========================================================================
@@ -482,11 +505,45 @@ async function playCompletionChime() {
 // Pipeline completion / error helpers
 // =========================================================================
 
-async function completePipeline() {
-    chrome.alarms.clear(ALARM_NAME);
+let notificationTargetQueue = Promise.resolve();
 
+function updateNotificationTargets(operation) {
+    const apply = async () => {
+        const stored = await chrome.storage.local.get('notificationTargets');
+        const targets = stored.notificationTargets || {};
+        const result = await operation(targets);
+        await chrome.storage.local.set({ notificationTargets: targets });
+        return result;
+    };
+    notificationTargetQueue = notificationTargetQueue.then(apply, apply);
+    return notificationTargetQueue;
+}
+
+async function rememberNotificationTarget(notificationId, notebookUrl) {
+    if (!notebookUrl) return;
+    await updateNotificationTargets(targets => {
+        targets[notificationId] = { notebookUrl, createdAt: Date.now() };
+        const obsoleteIds = Object.entries(targets)
+            .sort((a, b) => b[1].createdAt - a[1].createdAt)
+            .slice(10)
+            .map(([id]) => id);
+        for (const id of obsoleteIds) delete targets[id];
+    });
+}
+
+async function takeNotificationTarget(notificationId) {
+    return updateNotificationTargets(targets => {
+        const notebookUrl = targets[notificationId]?.notebookUrl || null;
+        delete targets[notificationId];
+        return notebookUrl;
+    });
+}
+
+async function completePipeline(runId) {
+    await requireActiveRun(runId, ['wait_artifacts']);
     const settings = await getSettings();
     const state = await getState();
+    if (!isActivePipelineRun(state, runId) || state.step !== 'wait_artifacts') return;
     const tasks = state.tasks || [];
     const totalCount = tasks.length;
     const completedCount = tasks.filter(t => t.status === 'completed').length;
@@ -494,22 +551,28 @@ async function completePipeline() {
     const allSucceeded = totalCount > 0 && failedCount === 0 && completedCount === totalCount;
 
     if (completedCount === 0) {
-        await failPipeline('All artifact generations failed. No artifacts were generated.', null, true);
+        await failPipeline(runId, 'All artifact generations failed. No artifacts were generated.');
         return;
     }
-
-    setBadge('\u2713', '#0fad6e');  // green check
 
     const stepDetail = allSucceeded
         ? 'All artifacts generated successfully!'
         : `Partial success: ${completedCount}/${totalCount} artifacts generated (${failedCount} failed).`;
 
-    await setState({
+    const completedState = await transitionRun(runId, {
         status: 'completed',
         step: 'done',
         stepDetail,
         completedAt: new Date().toISOString(),
+    }, {
+        expectedSteps: ['wait_artifacts'],
+        afterWrite: async () => {
+            try { await chrome.alarms.clear(ALARM_NAME); }
+            catch (error) { console.warn('[Alarm] Could not clear completion alarm:', error); }
+        },
     });
+    if (!completedState) return;
+    setBadge('\u2713', '#0fad6e').catch(error => console.warn('[Badge] Completion badge failed:', error));
 
     if (settings.chimeEnabled) {
         playCompletionChime();
@@ -524,7 +587,10 @@ async function completePipeline() {
         : `Notebook ${nbTitle}is partially ready with ${artifactLabel} (${failedCount} failed). Click to open.`;
 
     if (settings.notificationEnabled !== false) {
-        chrome.notifications.create('pipeline-complete', {
+        const notificationId = `pipeline-complete:${runId}`;
+        await rememberNotificationTarget(notificationId, state.notebookUrl)
+            .catch(error => console.warn('[Notification] Could not save notebook target:', error));
+        chrome.notifications.create(notificationId, {
             type: 'basic',
             iconUrl: 'icons/icon128.png',
             title: `\uD83C\uDFD9 Gemini Notebook Ready!`,
@@ -545,13 +611,10 @@ async function completePipeline() {
     console.log('[Pipeline] Completed successfully');
 }
 
-async function failPipeline(errorMsg, notebookId = null, sourceWasReady = false) {
-    chrome.alarms.clear(ALARM_NAME);
-    setBadge('!', '#e03e3e');  // red exclamation
-    const settings = await getSettings();
-
+async function failPipeline(runId, errorMsg, notebookId = null, canDeleteBlankNotebook = false) {
+    await requireActiveRun(runId);
     let cleanupMessage = '';
-    if (notebookId && !sourceWasReady) {
+    if (notebookId && canDeleteBlankNotebook) {
         try {
             await deleteNotebook(notebookId);
             cleanupMessage = ' Blank notebook was deleted automatically.';
@@ -562,15 +625,24 @@ async function failPipeline(errorMsg, notebookId = null, sourceWasReady = false)
     }
 
     const finalError = `${errorMsg}${cleanupMessage}`.trim();
-    await setState({
+    const failedState = await transitionRun(runId, {
         status: 'error',
         step: 'error',
         stepDetail: finalError,
         error: finalError,
+    }, {
+        afterWrite: async () => {
+            try { await chrome.alarms.clear(ALARM_NAME); }
+            catch (error) { console.warn('[Alarm] Could not clear failure alarm:', error); }
+        },
     });
+    if (!failedState) return;
+    setBadge('!', '#e03e3e').catch(error => console.warn('[Badge] Error badge failed:', error));
+
+    const settings = await getSettings();
 
     if (settings.notificationEnabled !== false) {
-        chrome.notifications.create('pipeline-error', {
+        chrome.notifications.create(`pipeline-error:${runId}`, {
             type: 'basic',
             iconUrl: 'icons/icon128.png',
             title: 'ScholarRelay Error',
@@ -592,6 +664,8 @@ async function failPipeline(errorMsg, notebookId = null, sourceWasReady = false)
  * and transitions state to 'wait_artifacts'.
  */
 async function tickSourcePoll(state) {
+    const runId = state.runId;
+    await requireActiveRun(runId, ['wait_source']);
     const SOURCE_TIMEOUT_MS = 600000; // 10 minutes
     const elapsed = pollingElapsedMs(state.stepStartedAt);
     const sourceLabel = getSourceLabel(state.sourceType);
@@ -599,9 +673,9 @@ async function tickSourcePoll(state) {
 
     if (elapsed > SOURCE_TIMEOUT_MS) {
         await failPipeline(
+            runId,
             `${sourceLabel} ingestion timed out after 10 minutes.`,
-            state.notebookId,
-            false   // source never became ready, delete the blank notebook
+            state.notebookId
         );
         return;
     }
@@ -609,10 +683,14 @@ async function tickSourcePoll(state) {
     let sources;
     try {
         sources = await listSources(state.notebookId);
+        await requireActiveRun(runId, ['wait_source']);
     } catch (err) {
+        if (err?.code === 'PIPELINE_STALE_RUN') return;
         // Transient network error -- log and retry next tick
         console.warn('[Tick] Could not list sources, will retry:', err.message);
-        await setState({ stepDetail: `Waiting for ${ingestionLabel} (${Math.round(elapsed / 1000)}s, retrying...)` });
+        await transitionRun(runId, {
+            stepDetail: `Waiting for ${ingestionLabel} (${Math.round(elapsed / 1000)}s, retrying...)`,
+        }, { expectedSteps: ['wait_source'] });
         return;
     }
 
@@ -620,29 +698,38 @@ async function tickSourcePoll(state) {
     const elapsedSec = Math.round(elapsed / 1000);
 
     if (!source) {
-        await setState({ stepDetail: `Waiting for ${sourceLabel} to appear (${elapsedSec}s elapsed)...` });
+        await transitionRun(runId, {
+            stepDetail: `Waiting for ${sourceLabel} to appear (${elapsedSec}s elapsed)...`,
+        }, { expectedSteps: ['wait_source'] });
         return;
     }
 
     if (source.status === SourceStatus.ERROR) {
-        await failPipeline(`${sourceLabel} processing failed.`, state.notebookId, false);
+        await failPipeline(runId, `${sourceLabel} processing failed.`, state.notebookId);
         return;
     }
 
     if (source.status !== SourceStatus.READY) {
-        await setState({ stepDetail: `${ingestionLabel} in progress (${elapsedSec}s elapsed)...` });
+        await transitionRun(runId, {
+            stepDetail: `${ingestionLabel} in progress (${elapsedSec}s elapsed)...`,
+        }, { expectedSteps: ['wait_source'] });
         return;
     }
 
     // Source is READY -- fetch notebook title, then trigger artifact generation
     console.log('[Tick] Source ready, triggering artifact generation');
-    await setState({ step: 'generate_artifacts', stepDetail: 'Source ready! Starting generation...' });
+    const claimed = await transitionRun(runId, {
+        step: 'generate_artifacts',
+        stepDetail: 'Source ready! Starting generation...',
+    }, { expectedSteps: ['wait_source'] });
+    if (!claimed) return;
 
     // Fetch the auto-generated notebook title and store it in state for display
     try {
         const title = await getNotebookTitle(state.notebookId);
+        await requireActiveRun(runId, ['generate_artifacts']);
         if (title) {
-            await setState({ notebookTitle: title });
+            await transitionRun(runId, { notebookTitle: title }, { expectedSteps: ['generate_artifacts'] });
             console.log(`[Tick] Notebook title: ${title}`);
         }
     } catch (titleErr) {
@@ -651,28 +738,34 @@ async function tickSourcePoll(state) {
 
     try {
         const settings = await getSettings();
+        await requireActiveRun(runId, ['generate_artifacts']);
 
         if (settings.collectionId) {
-            await setState({ stepDetail: 'Source ready! Adding notebook to collection...' });
+            await transitionRun(runId, {
+                stepDetail: 'Source ready! Adding notebook to collection...',
+            }, { expectedSteps: ['generate_artifacts'] });
             try {
+                await requireActiveRun(runId, ['generate_artifacts']);
                 const collection = await addNotebookToCollection(settings.collectionId, state.notebookId);
-                await setState({
+                await requireActiveRun(runId, ['generate_artifacts']);
+                await transitionRun(runId, {
                     collectionAssignment: {
                         collectionId: collection.id,
                         name: collection.name,
                         status: 'completed',
                     },
-                });
+                }, { expectedSteps: ['generate_artifacts'] });
             } catch (collectionErr) {
+                if (collectionErr?.code === 'PIPELINE_STALE_RUN') throw collectionErr;
                 console.warn('[Pipeline] Could not add notebook to collection:', collectionErr.message);
-                await setState({
+                await transitionRun(runId, {
                     collectionAssignment: {
                         collectionId: settings.collectionId,
                         name: null,
                         status: 'failed',
                         error: collectionErr.message,
                     },
-                });
+                }, { expectedSteps: ['generate_artifacts'] });
             }
         }
 
@@ -681,23 +774,28 @@ async function tickSourcePoll(state) {
 
         // Helper to run a generation function safely so one failure doesn't stop the pipeline
         const runTask = async (type, fn) => {
+            await requireActiveRun(runId, ['generate_artifacts']);
             try {
                 const res = await fn();
+                await requireActiveRun(runId, ['generate_artifacts']);
                 if (res?.status === 'completed') {
                     tasks.push({ type, taskId: res.taskId || null, status: 'completed' });
-                    return;
-                }
-                if (res?.status === 'failed') {
+                } else if (res?.status === 'failed') {
                     tasks.push({ type, taskId: res.taskId || null, status: 'failed', error: res.error || 'Artifact generation failed' });
-                    return;
+                } else {
+                    if (!res?.taskId) throw new Error('API returned no task ID');
+                    // Pending/unknown initial states are polled like in-progress tasks.
+                    tasks.push({ type, taskId: res.taskId, status: 'in_progress' });
                 }
-                if (!res?.taskId) throw new Error('API returned no task ID');
-                // Pending/unknown initial states are polled like in-progress tasks.
-                tasks.push({ type, taskId: res.taskId, status: 'in_progress' });
             } catch (e) {
+                if (e?.code === 'PIPELINE_STALE_RUN') throw e;
                 console.warn(`[Pipeline] Failed to start ${type}:`, e.message);
                 tasks.push({ type, taskId: null, status: 'failed', error: e.message });
             }
+            await transitionRun(runId, {
+                tasks: [...tasks],
+                stepDetail: `Started ${tasks.length} artifact request${tasks.length === 1 ? '' : 's'}...`,
+            }, { expectedSteps: ['generate_artifacts'] });
         };
 
         const artifactRequests = [
@@ -799,21 +897,23 @@ async function tickSourcePoll(state) {
             // Pace generation starts to reduce NotebookLM rate-limit bursts.
             if (i < artifactRequests.length - 1) {
                 await sleep(ARTIFACT_START_DELAY_MS);
+                await requireActiveRun(runId, ['generate_artifacts']);
             }
         }
 
         const typeLabels = tasks.map(t => t.type).join(', ');
-        await setState({
+        await transitionRun(runId, {
             tasks,
             step: 'wait_artifacts',
             stepDetail: `Generating: ${typeLabels}...`,
             stepStartedAt: new Date().toISOString(),
-        });
+        }, { expectedSteps: ['generate_artifacts'] });
     } catch (err) {
+        if (err?.code === 'PIPELINE_STALE_RUN') return;
         await failPipeline(
+            runId,
             `Failed to start artifact generation: ${err.message}`,
-            state.notebookId,
-            true   // source was ready, keep the notebook
+            state.notebookId
         );
     }
 }
@@ -823,11 +923,13 @@ async function tickSourcePoll(state) {
  * Polls all artifact tasks. Calls completePipeline() when all have settled.
  */
 async function tickArtifactPoll(state) {
+    const runId = state.runId;
+    await requireActiveRun(runId, ['wait_artifacts']);
     const ARTIFACT_TIMEOUT_MS = 1200000; // 20 minutes
     const elapsed = pollingElapsedMs(state.stepStartedAt);
 
     if (elapsed > ARTIFACT_TIMEOUT_MS) {
-        await failPipeline('Artifact generation timed out after 20 minutes.', null, true);
+        await failPipeline(runId, 'Artifact generation timed out after 20 minutes.');
         return;
     }
 
@@ -837,7 +939,9 @@ async function tickArtifactPoll(state) {
 
     try {
         statusByTaskId = await listArtifactStatuses(state.notebookId);
+        await requireActiveRun(runId, ['wait_artifacts']);
     } catch (err) {
+        if (err?.code === 'PIPELINE_STALE_RUN') return;
         console.warn('[Tick] Error listing artifact statuses:', err.message);
     }
 
@@ -857,16 +961,20 @@ async function tickArtifactPoll(state) {
 
     const elapsedMin = Math.round(elapsed / 60000);
     const summary = updatedTasks.map(t => `${t.type}: ${t.status}`).join(' | ');
-    await setState({ tasks: updatedTasks, stepDetail: `${summary} (~${elapsedMin} min elapsed)` });
+    const updated = await transitionRun(runId, {
+        tasks: updatedTasks,
+        stepDetail: `${summary} (~${elapsedMin} min elapsed)`,
+    }, { expectedSteps: ['wait_artifacts'] });
+    if (!updated) return;
 
     const allDone = updatedTasks.every(t => t.status !== 'in_progress');
     if (allDone && updatedTasks.length > 0) {
         const completedCount = updatedTasks.filter(t => t.status === 'completed').length;
         if (completedCount === 0) {
-            await failPipeline('All artifact generations failed. No artifacts were generated.', null, true);
+            await failPipeline(runId, 'All artifact generations failed. No artifacts were generated.');
             return;
         }
-        await completePipeline();
+        await completePipeline(runId);
     }
 }
 
@@ -878,11 +986,15 @@ const runExclusivePollTick = createExclusiveRunner();
 
 chrome.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name !== ALARM_NAME) return;
+    await bootReconciliationPromise;
     const ran = await runExclusivePollTick(async () => {
         const state = await getState();
 
         if (!state || state.status !== 'running') {
-            await chrome.alarms.clear(ALARM_NAME);
+            await pipelineState.effectWhen(
+                current => current?.status !== 'running',
+                () => chrome.alarms.clear(ALARM_NAME)
+            );
             return;
         }
 
@@ -912,33 +1024,34 @@ async function reconcilePipelineRuntime() {
     const action = runtimeRecoveryAction(state, !!alarm);
 
     if (action === 'create_alarm') {
-        await chrome.alarms.create(ALARM_NAME, {
-            periodInMinutes: PIPELINE_POLL_PERIOD_MINUTES,
-        });
-        console.log(`[Recovery] Restored ${ALARM_NAME} for ${state.step}`);
+        try {
+            await chrome.alarms.create(ALARM_NAME, {
+                periodInMinutes: PIPELINE_POLL_PERIOD_MINUTES,
+            });
+            console.log(`[Recovery] Restored ${ALARM_NAME} for ${state.step}`);
+        } catch (error) {
+            await setState(interruptedPipelineUpdate(state));
+            setBadge('!', '#e03e3e').catch(badgeError => console.warn('[Badge] Recovery badge failed:', badgeError));
+            console.warn('[Recovery] Could not restore polling alarm:', error);
+        }
     } else if (action === 'clear_alarm') {
         await chrome.alarms.clear(ALARM_NAME);
     } else if (action === 'interrupt') {
-        await chrome.alarms.clear(ALARM_NAME);
         await setState(interruptedPipelineUpdate(state));
-        setBadge('!', '#e03e3e');
+        chrome.alarms.clear(ALARM_NAME).catch(error => console.warn('[Alarm] Recovery cleanup failed:', error));
+        setBadge('!', '#e03e3e').catch(error => console.warn('[Badge] Recovery badge failed:', error));
         console.warn(`[Recovery] Stopped interrupted non-idempotent phase: ${state?.step}`);
     }
 }
 
-chrome.runtime.onStartup.addListener(() => {
-    reconcilePipelineRuntime().catch(error => console.warn('[Recovery] Startup reconciliation failed:', error));
-});
-
-chrome.runtime.onInstalled.addListener(() => {
-    reconcilePipelineRuntime().catch(error => console.warn('[Recovery] Install reconciliation failed:', error));
-});
+const bootReconciliationPromise = reconcilePipelineRuntime()
+    .catch(error => console.warn('[Recovery] Initial reconciliation failed:', error));
 
 // =========================================================================
 // Pipeline orchestration (steps 1-3: synchronous network calls)
 // =========================================================================
 
-async function runPipeline(pdfUrl, pageUrl, uploadFile = null, sourceType = 'pdf', sourceTitle = null) {
+async function runPipeline(runId, pdfUrl, pageUrl, uploadFile = null, sourceType = 'pdf', sourceTitle = null) {
     const effectiveSourceType = uploadFile ? 'pdf' : (sourceType || 'pdf');
     const sourceLabel = getSourceLabel(effectiveSourceType);
     const ingestionLabel = getIngestionLabel(effectiveSourceType);
@@ -946,56 +1059,47 @@ async function runPipeline(pdfUrl, pageUrl, uploadFile = null, sourceType = 'pdf
     console.log(`[Pipeline] Starting for ${sourceLabel}: ${pdfUrl}`);
 
     let notebookId = null;
+    let sourceMutationStarted = false;
 
     try {
-        setBadge('...', '#6b7a8d');  // grey ellipsis while running
-
         // Step 1: Authenticate
-        await setState({
-            status: 'running',
-            step: 'auth',
-            stepDetail: 'Connecting to Gemini Notebook...',
-            pdfUrl,
-            sourceType: effectiveSourceType,
-            pageUrl,
-            sourceTitle: detectedTitle || null,
-            notebookId: null,
-            notebookUrl: null,
-            notebookTitle: null,
-            sourceId: null,
-            collectionAssignment: null,
-            tasks: [],
-            error: null,
-            startedAt: new Date().toISOString(),
-            completedAt: null,
-            stepStartedAt: new Date().toISOString(),
-        });
-
+        await requireActiveRun(runId, ['auth']);
         await fetchTokens();
-        await setState({ step: 'create_notebook', stepDetail: 'Creating notebook...' });
+        await requireActiveRun(runId, ['auth']);
+        const creating = await transitionRun(runId, {
+            step: 'create_notebook',
+            stepDetail: 'Creating notebook...',
+        }, { expectedSteps: ['auth'] });
+        if (!creating) return;
 
         // Step 2: Create notebook
         const settings = await getSettings();
         const requestedNotebookTitle = settings.useSourceTitleForNotebook !== false ? detectedTitle : '';
+        await requireActiveRun(runId, ['create_notebook']);
         const notebook = await createNotebook(requestedNotebookTitle);
         if (!notebook.id) throw new Error('Failed to create notebook -- no ID returned');
         notebookId = notebook.id;
+        await requireActiveRun(runId, ['create_notebook']);
 
         const notebookUrl = getNotebookUrl(notebook.id);
         const sourceStepDetail = uploadFile
             ? `Uploading local PDF: ${uploadFile.filename}`
             : `Adding ${sourceLabel}: ${pdfUrl.substring(0, 60)}...`;
 
-        await setState({
+        const adding = await transitionRun(runId, {
             notebookId: notebook.id,
             notebookUrl,
             step: 'add_source',
             stepDetail: sourceStepDetail,
-        });
+        }, { expectedSteps: ['create_notebook'] });
+        if (!adding) return;
 
         // Step 3: Add source
         let source = null;
         if (uploadFile) {
+            assertPdfUploadSize(decodedBase64ByteLength(uploadFile.fileData));
+            await requireActiveRun(runId, ['add_source']);
+            sourceMutationStarted = true;
             source = await addFileSource(
                 notebook.id,
                 uploadFile.filename,
@@ -1008,55 +1112,70 @@ async function runPipeline(pdfUrl, pageUrl, uploadFile = null, sourceType = 'pdf
             }
             const canFallbackToPdfUpload = !isWebpageSourceType(effectiveSourceType) && isLikelyPdfUrl(pdfUrl);
             try {
+                await requireActiveRun(runId, ['add_source']);
+                sourceMutationStarted = true;
                 source = await addUrlSource(notebook.id, pdfUrl);
             } catch (urlErr) {
+                if (urlErr?.code === 'PIPELINE_STALE_RUN') throw urlErr;
                 if (!canFallbackToPdfUpload) {
                     throw urlErr;
                 }
                 console.warn('[Pipeline] URL source add failed, trying download+upload fallback:', urlErr?.message || urlErr);
-                await setState({
+                await transitionRun(runId, {
                     stepDetail: 'URL source was blocked. Downloading PDF from the current URL and uploading directly...'
-                });
+                }, { expectedSteps: ['add_source'] });
 
                 try {
                     const fallbackFile = await downloadRemotePdfForUpload(pdfUrl, pageUrl);
+                    await requireActiveRun(runId, ['add_source']);
                     source = await addFileSource(
                         notebook.id,
                         fallbackFile.filename,
                         fallbackFile.fileData,
                         fallbackFile.mimeType
                     );
-                    await setState({
+                    await requireActiveRun(runId, ['add_source']);
+                    await transitionRun(runId, {
                         stepDetail: `URL blocked. Fallback upload succeeded (${fallbackFile.filename}).`
-                    });
+                    }, { expectedSteps: ['add_source'] });
                 } catch (fallbackErr) {
+                    if (fallbackErr?.code === 'PIPELINE_STALE_RUN') throw fallbackErr;
                     throw new Error(buildFallbackUploadErrorMessage(urlErr, fallbackErr, pdfUrl));
                 }
             }
         }
 
         if (!source.id) throw new Error('Failed to add source -- no ID returned');
+        await requireActiveRun(runId, ['add_source']);
 
         // Step 4: Hand off to alarm-based polling.
         // The service worker is free to be suspended between alarm ticks.
         // All state needed for polling is now in chrome.storage.local.
-        await setState({
+        const polling = await transitionRun(runId, {
             sourceId: source.id,
             step: 'wait_source',
             stepDetail: `Waiting for ${ingestionLabel} (checking every ~30s)...`,
             stepStartedAt: new Date().toISOString(),
+        }, {
+            expectedSteps: ['add_source'],
+            afterWrite: async () => {
+                await chrome.alarms.clear(ALARM_NAME);
+                await chrome.alarms.create(ALARM_NAME, {
+                    periodInMinutes: PIPELINE_POLL_PERIOD_MINUTES,
+                });
+            },
         });
-
-        await chrome.alarms.clear(ALARM_NAME);
-        await chrome.alarms.create(ALARM_NAME, {
-            periodInMinutes: PIPELINE_POLL_PERIOD_MINUTES,
-        });
+        if (!polling) return;
         console.log('[Pipeline] Alarm-based polling started (30 s interval)');
 
     } catch (err) {
+        if (err?.code === 'PIPELINE_STALE_RUN') {
+            console.log(`[Pipeline] Ignoring stale run ${runId}`);
+            return;
+        }
         const msg = err?.message || 'Unknown error';
         console.error('[Pipeline] Setup error:', err);
-        await failPipeline(msg, notebookId, false);
+        await failPipeline(runId, msg, notebookId, !!notebookId && !sourceMutationStarted);
     }
 }
 
@@ -1064,18 +1183,105 @@ async function runPipeline(pdfUrl, pageUrl, uploadFile = null, sourceType = 'pdf
 // Message handlers (from popup and content script)
 // =========================================================================
 
+async function startPipelineRequest(message, uploadFile = null) {
+    await bootReconciliationPromise;
+
+    if (uploadFile) {
+        const decodedSize = decodedBase64ByteLength(uploadFile.fileData);
+        assertPdfUploadSize(decodedSize);
+        if (!hasBase64PdfSignature(uploadFile.fileData)) {
+            throw new Error('The selected file does not contain a PDF signature.');
+        }
+    }
+
+    const runId = crypto.randomUUID();
+    const sourceType = uploadFile ? 'pdf' : (message.sourceType || 'pdf');
+    const initialState = {
+        ...INITIAL_STATE,
+        status: 'running',
+        runId,
+        step: 'auth',
+        stepDetail: 'Connecting to Gemini Notebook...',
+        pdfUrl: uploadFile ? uploadFile.filename : message.pdfUrl,
+        sourceType,
+        pageUrl: message.pageUrl || null,
+        sourceTitle: normalizeSourceTitle(message.sourceTitle) || null,
+        startedAt: new Date().toISOString(),
+        stepStartedAt: new Date().toISOString(),
+    };
+
+    const claimed = await pipelineState.claim(runId, initialState, {
+    });
+    if (!claimed.applied) {
+        const alreadyRunning = claimed.state?.status === 'running';
+        return {
+            ok: false,
+            code: alreadyRunning ? 'PIPELINE_ALREADY_RUNNING' : 'PIPELINE_NOT_IDLE',
+            message: alreadyRunning
+                ? 'Another pipeline is already active. Open the popup to review or stop it first.'
+                : 'Reset the completed or failed pipeline before starting a new one.',
+            state: claimed.state,
+        };
+    }
+
+    try { await chrome.alarms.clear(ALARM_NAME); }
+    catch (error) { console.warn('[Alarm] Could not clear an old polling alarm:', error); }
+    setBadge('...', '#6b7a8d').catch(error => console.warn('[Badge] Start badge failed:', error));
+
+    runPipeline(
+        runId,
+        uploadFile ? uploadFile.filename : message.pdfUrl,
+        message.pageUrl || null,
+        uploadFile,
+        sourceType,
+        message.sourceTitle || null
+    ).catch(error => console.error('[Pipeline] Unhandled setup failure:', error));
+
+    return { ok: true, runId, message: 'Pipeline started' };
+}
+
+async function stopPipelineRequest(requestedRunId) {
+    await bootReconciliationPromise;
+    const state = await getState();
+    if (!requestedRunId || !canStopPipeline(state, requestedRunId)) {
+        return {
+            ok: false,
+            code: 'PIPELINE_NOT_STOPPABLE',
+            message: 'This pipeline has already advanced or is no longer the active run.',
+            state,
+        };
+    }
+
+    const replacement = {
+        ...INITIAL_STATE,
+        status: 'idle',
+        stepDetail: 'Monitoring stopped. No further work will be started.',
+    };
+    const stopped = await pipelineState.invalidate(requestedRunId, replacement, {
+        expectedSteps: ['wait_source', 'wait_artifacts'],
+        afterWrite: async () => {
+            await chrome.alarms.clear(ALARM_NAME);
+        },
+    });
+    if (stopped.applied) {
+        clearBadge().catch(error => console.warn('[Badge] Clear badge failed:', error));
+    }
+    return stopped.applied
+        ? { ok: true, message: replacement.stepDetail }
+        : {
+            ok: false,
+            code: 'PIPELINE_NOT_STOPPABLE',
+            message: 'This pipeline changed before it could be stopped.',
+            state: stopped.state,
+        };
+}
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.type === 'START_PIPELINE') {
-        chrome.alarms.clear(ALARM_NAME);
-        runPipeline(
-            message.pdfUrl,
-            message.pageUrl,
-            null,
-            message.sourceType || 'pdf',
-            message.sourceTitle || null
-        );
-        sendResponse({ ok: true, message: 'Pipeline started' });
-        return false;
+        startPipelineRequest(message)
+            .then(sendResponse)
+            .catch(error => sendResponse({ ok: false, code: error?.code, message: error?.message || 'Could not start pipeline' }));
+        return true;
     }
 
     if (message.type === 'START_PIPELINE_FILE') {
@@ -1083,29 +1289,23 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             sendResponse({ ok: false, message: 'Missing file payload or filename' });
             return false;
         }
-        chrome.alarms.clear(ALARM_NAME);
-        runPipeline(
-            message.fileName || 'local-upload.pdf',
-            message.pageUrl || null,
-            {
+        startPipelineRequest(message, {
                 filename: message.fileName || 'local-upload.pdf',
                 mimeType: message.mimeType || 'application/pdf',
                 fileData: message.fileDataBase64,
-            },
-            'pdf',
-            message.sourceTitle || null
-        );
-        sendResponse({ ok: true, message: 'Pipeline started' });
-        return false;
+            })
+            .then(sendResponse)
+            .catch(error => sendResponse({ ok: false, code: error?.code, message: error?.message || 'Could not start file pipeline' }));
+        return true;
     }
 
     if (message.type === 'GET_STATE') {
-        getState().then(state => sendResponse(state));
+        bootReconciliationPromise.then(() => getState()).then(sendResponse);
         return true;
     }
 
     if (message.type === 'LIST_COLLECTIONS') {
-        listCollections()
+        bootReconciliationPromise.then(() => listCollections())
             .then(collections => sendResponse({ ok: true, collections }))
             .catch(error => sendResponse({
                 ok: false,
@@ -1116,28 +1316,36 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
 
     if (message.type === 'RESET_STATE') {
-        chrome.alarms.clear(ALARM_NAME);
-        clearBadge();
-        resetState().then(() => sendResponse({ ok: true }));
+        bootReconciliationPromise
+            .then(() => resetState({
+                afterWrite: async () => {
+                    await chrome.alarms.clear(ALARM_NAME);
+                },
+            }))
+            .then(state => {
+                if (state) clearBadge().catch(error => console.warn('[Badge] Clear badge failed:', error));
+                sendResponse(state
+                    ? { ok: true }
+                    : { ok: false, code: 'PIPELINE_ALREADY_RUNNING', message: 'Stop the active pipeline before resetting.' });
+            })
+            .catch(error => sendResponse({ ok: false, message: error?.message || 'Could not reset pipeline state' }));
         return true;
     }
 
     if (message.type === 'ABORT_PIPELINE') {
-        chrome.alarms.clear(ALARM_NAME);
-        clearBadge();
-        setState({
-            ...INITIAL_STATE,
-            status: 'idle',
-            stepDetail: 'Monitoring stopped. You can start another generation.',
-            error: null,
-        }).then(() => sendResponse({ ok: true }));
+        stopPipelineRequest(message.runId).then(sendResponse)
+            .catch(error => sendResponse({ ok: false, message: error?.message || 'Could not stop monitoring' }));
         return true;
     }
 
     if (message.type === 'DETECT_PDF') {
-        chrome.storage.local.set({ detectedPdf: message.data });
-        sendResponse({ ok: true });
-        return false;
+        const detectedPdf = bindDetectionToTab(message.data, sender.tab);
+        if (!detectedPdf) {
+            sendResponse({ ok: false, message: 'Detection was not associated with a browser tab.' });
+            return false;
+        }
+        chrome.storage.local.set({ detectedPdf }).then(() => sendResponse({ ok: true }));
+        return true;
     }
 });
 
@@ -1147,10 +1355,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Clicking the notification body opens the notebook
 chrome.notifications.onClicked.addListener(async (notificationId) => {
-    if (notificationId === 'pipeline-complete') {
-        const state = await getState();
-        if (state.notebookUrl) {
-            chrome.tabs.create({ url: state.notebookUrl });
+    if (notificationId.startsWith('pipeline-complete:')) {
+        const notebookUrl = await takeNotificationTarget(notificationId);
+        if (notebookUrl) {
+            chrome.tabs.create({ url: notebookUrl });
         }
         chrome.notifications.clear(notificationId);
     }
@@ -1158,11 +1366,11 @@ chrome.notifications.onClicked.addListener(async (notificationId) => {
 
 // Handling the "Open Notebook" / "Dismiss" action buttons
 chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {
-    if (notificationId === 'pipeline-complete') {
+    if (notificationId.startsWith('pipeline-complete:')) {
+        const notebookUrl = await takeNotificationTarget(notificationId);
         if (buttonIndex === 0) {
-            const state = await getState();
-            if (state.notebookUrl) {
-                chrome.tabs.create({ url: state.notebookUrl });
+            if (notebookUrl) {
+                chrome.tabs.create({ url: notebookUrl });
             }
         }
         // buttonIndex 1 = "Dismiss" -- just clear
@@ -1170,5 +1378,10 @@ chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIn
     }
 });
 
+chrome.notifications.onClosed.addListener(notificationId => {
+    if (notificationId.startsWith('pipeline-complete:')) {
+        takeNotificationTarget(notificationId).catch(error => console.warn('[Notification] Could not clear target:', error));
+    }
+});
+
 console.log('[ScholarRelay] Service worker loaded');
-reconcilePipelineRuntime().catch(error => console.warn('[Recovery] Initial reconciliation failed:', error));

--- a/content.js
+++ b/content.js
@@ -14,8 +14,6 @@
     if (window.__pdfDetectorInjected) return;
     window.__pdfDetectorInjected = true;
 
-    const currentUrl = window.location.href;
-
     function detectSourceTitle() {
         const candidates = [
             document.querySelector('meta[name="citation_title"]')?.content,
@@ -32,6 +30,7 @@
      * Returns { isPdf, pdfUrl, pageUrl, source }
      */
     function detectPdf() {
+        const currentUrl = window.location.href;
         const pageUrl = currentUrl;
         const sourceTitle = detectSourceTitle();
 

--- a/detection-policy.js
+++ b/detection-policy.js
@@ -1,0 +1,27 @@
+export function bindDetectionToTab(detection, tab) {
+  if (!detection || !Number.isInteger(tab?.id) || typeof tab?.url !== 'string') return null;
+  return {
+    ...detection,
+    tabId: tab.id,
+    tabUrl: tab.url,
+    detectedAt: new Date().toISOString(),
+  };
+}
+
+export function detectionMatchesTab(detection, tab) {
+  return !!detection &&
+    Number.isInteger(detection.tabId) &&
+    Number.isInteger(tab?.id) &&
+    detection.tabId === tab.id &&
+    typeof detection.tabUrl === 'string' &&
+    typeof tab?.url === 'string' &&
+    detection.tabUrl === tab.url &&
+    detection.pageUrl === tab.url;
+}
+
+export function directDetectionMatchesTab(detection, tab) {
+  return !!detection &&
+    typeof detection.pageUrl === 'string' &&
+    typeof tab?.url === 'string' &&
+    detection.pageUrl === tab.url;
+}

--- a/docs/chrome-web-store-listing.md
+++ b/docs/chrome-web-store-listing.md
@@ -32,6 +32,8 @@ Choose any supported combination of Audio Overview, Video Overview, report, quiz
 
 ScholarRelay uses the Gemini Notebook session already established in Chrome. It never asks for or stores your Google password or verification codes. A PDF hosted on a different website may require a one-time Chrome permission prompt for that specific website. If access is declined, ScholarRelay tries URL import and keeps manual PDF upload available.
 
+Direct PDF downloads and local uploads are limited to 32 MiB to keep Chrome memory use safe. Larger remote PDFs use URL import, while larger local files can be uploaded directly in Gemini Notebook.
+
 ScholarRelay is an independent, open-source extension and is not affiliated with, authorized by, or endorsed by Google. Gemini Notebook was formerly named NotebookLM. ScholarRelay integrates with the consumer web application rather than an official consumer API, so service changes can affect compatibility.
 
 ## 한국어 스토어 등록 문구
@@ -53,6 +55,8 @@ ScholarRelay는 직접 열린 PDF, arXiv 논문, 웹페이지에 연결된 PDF �
 오디오 오버뷰, 비디오 오버뷰, 보고서, 퀴즈, 플래시카드, 인포그래픽, 슬라이드, 마인드맵, 데이터 표를 원하는 조합으로 선택할 수 있습니다. 팝업을 닫은 뒤에도 생성 상태를 확인하며, 선택 사항인 알림, 완료 차임 및 노트북 자동 열기로 결과가 준비되었는지 확인할 수 있습니다.
 
 ScholarRelay는 Chrome에 이미 로그인된 Gemini Notebook 세션을 사용합니다. Google 비밀번호나 인증 코드를 요청하거나 저장하지 않습니다. PDF가 현재 페이지와 다른 사이트에 있으면 해당 사이트에 한정된 일회성 Chrome 권한 요청이 표시될 수 있습니다. 권한을 거부하면 URL 가져오기를 시도하고, 직접 PDF를 업로드할 수 있는 방법도 유지합니다.
+
+Chrome 메모리를 안전하게 유지하기 위해 직접 PDF 다운로드와 로컬 업로드는 32 MiB로 제한됩니다. 더 큰 원격 PDF는 URL 가져오기를 사용하고, 더 큰 로컬 파일은 Gemini Notebook에서 직접 업로드할 수 있습니다.
 
 ScholarRelay는 독립적인 오픈 소스 확장 프로그램이며 Google과 제휴하거나 Google의 승인 또는 보증을 받지 않았습니다. Gemini Notebook의 이전 명칭은 NotebookLM입니다. 공식 소비자용 API가 아닌 소비자 웹 애플리케이션과 연동하므로 서비스 변경에 따라 호환성 업데이트가 필요할 수 있습니다.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "node --test",
+    "smoke:chrome": "node ./scripts/smoke-extension.mjs",
     "capture:assets": "node ./scripts/capture-assets.mjs",
     "package:store": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/package-store.ps1"
   }

--- a/pdf-file-policy.js
+++ b/pdf-file-policy.js
@@ -1,0 +1,103 @@
+export const MAX_PDF_UPLOAD_BYTES = 32 * 1024 * 1024;
+
+export function decodedBase64ByteLength(value) {
+  if (typeof value !== 'string') return 0;
+  const payload = value.includes(',') ? value.slice(value.indexOf(',') + 1) : value;
+  const compact = payload.replace(/\s+/g, '');
+  if (!compact) return 0;
+  const padding = compact.endsWith('==') ? 2 : compact.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((compact.length * 3) / 4) - padding);
+}
+
+export function pdfSizeError(size, limit = MAX_PDF_UPLOAD_BYTES) {
+  const limitMiB = Math.floor(limit / (1024 * 1024));
+  const actualMiB = Number.isFinite(size) ? (size / (1024 * 1024)).toFixed(1) : 'unknown';
+  const error = new Error(
+    `This PDF is ${actualMiB} MiB. ScholarRelay local uploads are limited to ${limitMiB} MiB ` +
+    'to keep Chrome memory use safe. Use the PDF URL directly or choose a smaller file.'
+  );
+  error.code = 'PDF_TOO_LARGE';
+  return error;
+}
+
+export function assertPdfUploadSize(size, limit = MAX_PDF_UPLOAD_BYTES) {
+  if (!Number.isFinite(size) || size < 0 || size > limit) throw pdfSizeError(size, limit);
+  return size;
+}
+
+export async function readResponseWithinLimit(response, limit = MAX_PDF_UPLOAD_BYTES) {
+  const contentLengthHeader = response?.headers?.get?.('content-length');
+  if (contentLengthHeader !== null && contentLengthHeader !== undefined && contentLengthHeader !== '') {
+    try {
+      assertPdfUploadSize(Number(contentLengthHeader), limit);
+    } catch (error) {
+      try { await response?.body?.cancel?.('PDF exceeds the safe local upload limit'); } catch {}
+      throw error;
+    }
+  }
+  if (!response?.body?.getReader) {
+    const error = new Error('The PDF response cannot be streamed safely in this browser. Use URL import instead.');
+    error.code = 'PDF_STREAM_UNAVAILABLE';
+    throw error;
+  }
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value?.byteLength) continue;
+      total += value.byteLength;
+      if (total > limit) {
+        try { await reader.cancel('PDF exceeds the safe local upload limit'); } catch {}
+        throw pdfSizeError(total, limit);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    try { reader.releaseLock(); } catch {}
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+export function hasPdfSignature(payload) {
+  let bytes;
+  if (payload instanceof ArrayBuffer) bytes = new Uint8Array(payload);
+  else if (ArrayBuffer.isView(payload)) bytes = new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength);
+  else return false;
+
+  const scanLength = Math.min(bytes.length, 1024);
+  for (let i = 0; i <= scanLength - 5; i += 1) {
+    if (bytes[i] === 0x25 && bytes[i + 1] === 0x50 && bytes[i + 2] === 0x44 &&
+        bytes[i + 3] === 0x46 && bytes[i + 4] === 0x2d) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasBase64PdfSignature(value) {
+  if (typeof value !== 'string') return false;
+  const payload = value.includes(',') ? value.slice(value.indexOf(',') + 1) : value;
+  const compact = payload.replace(/\s+/g, '');
+  if (!compact) return false;
+  const prefixLength = Math.min(compact.length, 2048);
+  const alignedLength = prefixLength - (prefixLength % 4);
+  try {
+    const binary = atob(compact.slice(0, alignedLength || prefixLength));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return hasPdfSignature(bytes);
+  } catch {
+    return false;
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -327,6 +327,18 @@
       color: var(--success);
     }
 
+    .pipeline-error-box {
+      margin-top: 10px;
+      padding: 10px 12px;
+      border: 1px solid color-mix(in srgb, var(--error) 55%, transparent);
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--error) 10%, transparent);
+      color: var(--error);
+      font-size: 12px;
+      line-height: 1.45;
+      overflow-wrap: anywhere;
+    }
+
     .collection-status {
       margin: 8px 0;
       padding: 7px 9px;

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,11 @@
 import { choosePdfTitle } from './pdf-metadata.js';
+import { detectionMatchesTab, directDetectionMatchesTab } from './detection-policy.js';
+import {
+    MAX_PDF_UPLOAD_BYTES,
+    assertPdfUploadSize,
+    hasPdfSignature,
+    readResponseWithinLimit,
+} from './pdf-file-policy.js';
 import { httpOriginPattern, needsOptionalPdfAccess } from './site-permissions.js';
 
 /**
@@ -360,8 +367,9 @@ async function detectSourceTitleFromTab(tab) {
 }
 
 async function detectAndRender() {
+    let tab = null;
     try {
-        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
         if (tab?.url) {
             const url = tab.url;
             const sourceTitle = await detectSourceTitleFromTab(tab);
@@ -391,16 +399,21 @@ async function detectAndRender() {
 
     try {
         const stored = await chrome.storage.local.get('detectedPdf');
-        if (stored.detectedPdf?.isPdf) { renderDetection(stored.detectedPdf); return; }
+        if (stored.detectedPdf?.isPdf && detectionMatchesTab(stored.detectedPdf, tab)) {
+            renderDetection(stored.detectedPdf);
+            return;
+        }
     } catch (_) { /* ignore */ }
 
     try {
-        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
         if (tab?.id && tab?.url && !tab.url.startsWith('chrome://')) {
             await chrome.scripting.executeScript({ target: { tabId: tab.id }, files: ['content.js'] });
             await new Promise(r => setTimeout(r, 200));
             const response = await chrome.tabs.sendMessage(tab.id, { type: 'REQUEST_PDF_DETECTION' });
-            if (response?.isPdf) { renderDetection(response); return; }
+            if (response?.isPdf && directDetectionMatchesTab(response, tab)) {
+                renderDetection(response);
+                return;
+            }
         }
     } catch (_) { /* ignore */ }
 
@@ -514,7 +527,10 @@ function renderProgress(state) {
         <div class="msg">${summaryMsg}</div>
       </div>`;
     }
-    if (state.status === 'running') {
+    if (state.status === 'error') {
+        bottomHtml += `<div class="pipeline-error-box" role="alert">${escapeHtml(state.error || state.stepDetail || 'The pipeline failed.')}</div>`;
+    }
+    if (state.status === 'running' && ['wait_source', 'wait_artifacts'].includes(state.step)) {
         bottomHtml += `<button class="btn-secondary" id="btn-abort">Stop Monitoring</button>`;
     }
     if (state.status === 'error' || state.status === 'completed') {
@@ -532,10 +548,18 @@ function renderProgress(state) {
     ${bottomHtml}`;
 
     document.getElementById('btn-reset')?.addEventListener('click', async () => {
-        await chrome.runtime.sendMessage({ type: 'RESET_STATE' });
-        await detectAndRender();
+        try {
+            const response = await chrome.runtime.sendMessage({ type: 'RESET_STATE' });
+            if (!response?.ok) {
+                alert(response?.message || 'Could not reset pipeline state.');
+                return;
+            }
+            await detectAndRender();
+        } catch (error) {
+            alert(error?.message || 'The service worker did not respond. Reopen the popup and try again.');
+        }
     });
-    document.getElementById('btn-abort')?.addEventListener('click', abortPipeline);
+    document.getElementById('btn-abort')?.addEventListener('click', () => abortPipeline(state.runId));
 }
 
 // =========================================================================
@@ -544,12 +568,29 @@ function renderProgress(state) {
 
 async function startPipeline(pdfUrl, pageUrl, sourceType = 'pdf', sourceTitle = null) {
     const btn = document.getElementById('btn-start') || document.getElementById('btn-start-url');
+    const originalText = btn?.textContent || '';
     if (btn) { btn.disabled = true; btn.textContent = '⏳ Starting...'; }
-    await chrome.runtime.sendMessage({ type: 'START_PIPELINE', pdfUrl, pageUrl, sourceType, sourceTitle });
-    await new Promise(r => setTimeout(r, 300));
-    const state = await getState();
-    renderProgress(state);
-    startPolling();
+    try {
+        const response = await chrome.runtime.sendMessage({ type: 'START_PIPELINE', pdfUrl, pageUrl, sourceType, sourceTitle });
+        if (!response?.ok) {
+            const error = new Error(response?.message || 'Could not start pipeline');
+            error.code = response?.code;
+            throw error;
+        }
+        const state = await getState();
+        if (state.runId !== response.runId || state.status !== 'running') {
+            throw new Error('The pipeline did not retain ownership after starting.');
+        }
+        renderProgress(state);
+        startPolling();
+        return response;
+    } catch (error) {
+        if (btn?.isConnected) {
+            btn.disabled = false;
+            btn.textContent = originalText;
+        }
+        throw error;
+    }
 }
 
 async function startPipelineFromCurrentPageUrl() {
@@ -571,33 +612,66 @@ async function startPipelineFromCurrentPageUrl() {
     }
 }
 
-async function abortPipeline() {
-    await chrome.runtime.sendMessage({ type: 'ABORT_PIPELINE' });
-    stopPolling();
-    await detectAndRender();
+async function abortPipeline(runId) {
+    try {
+        const response = await chrome.runtime.sendMessage({ type: 'ABORT_PIPELINE', runId });
+        if (!response?.ok) {
+            const current = response?.state || await getState();
+            renderProgress(current);
+            if (current.status === 'running') startPolling();
+            alert(response?.message || 'The pipeline could not be stopped.');
+            return;
+        }
+        stopPolling();
+        await detectAndRender();
+    } catch (error) {
+        alert(error?.message || 'The service worker did not respond. Reopen the popup and try again.');
+    }
 }
 
 async function startPipelineFile(file, pageUrl, sourceTitle = null) {
     const btn = document.getElementById('btn-upload-start') || document.getElementById('btn-upload-manual');
+    const originalText = btn?.textContent || '';
     if (btn) { btn.disabled = true; btn.textContent = 'Uploading...'; }
-    const fileDataBase64 = await readFileAsBase64(file);
-    const selectedTitle = choosePdfTitle({
-        payload: fileDataBase64,
-        pageTitle: sourceTitle,
-        filename: file.name,
-    });
-    console.log(`[Popup] Notebook title source: ${selectedTitle.source}`);
-    await chrome.runtime.sendMessage({
-        type: 'START_PIPELINE_FILE',
-        fileName: file.name || 'local-upload.pdf',
-        mimeType: file.type || 'application/pdf',
-        fileDataBase64, pageUrl,
-        sourceTitle: selectedTitle.title,
-    });
-    await new Promise(r => setTimeout(r, 300));
-    const state = await getState();
-    renderProgress(state);
-    startPolling();
+    try {
+        assertPdfUploadSize(file.size);
+        const signature = await file.slice(0, 1024).arrayBuffer();
+        if (!hasPdfSignature(signature)) throw new Error('The selected file does not contain a PDF signature.');
+        const fileDataBase64 = await readFileAsBase64(file);
+        const selectedTitle = choosePdfTitle({
+            payload: fileDataBase64,
+            pageTitle: sourceTitle,
+            filename: file.name,
+        });
+        console.log(`[Popup] Notebook title source: ${selectedTitle.source}`);
+        const response = await chrome.runtime.sendMessage({
+            type: 'START_PIPELINE_FILE',
+            fileName: file.name || 'local-upload.pdf',
+            mimeType: file.type || 'application/pdf',
+            fileDataBase64, pageUrl,
+            sourceTitle: selectedTitle.title,
+        });
+        if (!response?.ok) {
+            const error = new Error(response?.message || 'Could not start file pipeline');
+            error.code = response?.code;
+            throw error;
+        }
+        const state = await getState();
+        if (state.runId !== response.runId || state.status !== 'running') {
+            throw new Error('The file pipeline did not retain ownership after starting.');
+        }
+        renderProgress(state);
+        startPolling();
+        return true;
+    } catch (error) {
+        console.warn('[Popup] Could not start local PDF pipeline:', error?.message || error);
+        if (btn?.isConnected) {
+            btn.disabled = false;
+            btn.textContent = originalText;
+        }
+        alert(error?.message || 'Could not upload the selected PDF.');
+        return false;
+    }
 }
 
 function blobToBase64(blob) {
@@ -688,12 +762,10 @@ async function tryDirectTabPdfRead(tab, preferredPdfUrl = null) {
         if (!response.ok) {
             return { ok: false, error: `HTTP ${response.status}` };
         }
-        const blob = await response.blob();
-        const mimeType = blob.type || 'application/pdf';
-        const looksLikePdf = /pdf/i.test(mimeType) || /\.pdf(\?|#|$)/i.test(sourceUrl);
-        if (!looksLikePdf) {
-            return { ok: false, error: 'Current tab content is not a PDF' };
-        }
+        const bytes = await readResponseWithinLimit(response);
+        const mimeType = response.headers.get('content-type') || 'application/pdf';
+        if (!hasPdfSignature(bytes)) return { ok: false, error: 'Current tab content is not a valid PDF' };
+        const blob = new Blob([bytes], { type: mimeType });
         const fileDataBase64 = await blobToBase64(blob);
         return {
             ok: true,
@@ -703,7 +775,7 @@ async function tryDirectTabPdfRead(tab, preferredPdfUrl = null) {
             sourceUrl,
         };
     } catch (e) {
-        return { ok: false, error: e?.message || 'Could not fetch PDF from active tab URL' };
+        return { ok: false, code: e?.code, error: e?.message || 'Could not fetch PDF from active tab URL' };
     }
 }
 
@@ -744,11 +816,30 @@ async function startPipelineFromCurrentTabPdf(pageUrl, pdfUrl = null, detectedSo
 
         let payload = await tryDirectTabPdfRead(tab, pdfUrl);
 
+        if (payload?.code === 'PDF_TOO_LARGE') {
+            if (/^https?:\/\//i.test(pdfUrl || '')) {
+                console.log('[Popup] PDF is too large for the local bridge; using Gemini Notebook URL import');
+                await startPipeline(pdfUrl, pageUrl || tab.url || pdfUrl, 'pdf', pageTitle);
+                return;
+            }
+            const error = new Error(payload.error || 'This local PDF exceeds the 32 MiB safe upload limit.');
+            error.code = payload.code;
+            throw error;
+        }
+        if (payload?.error === 'FILE_ACCESS_DISABLED') {
+            showFileAccessHint();
+            if (btn) {
+                btn.disabled = false;
+                btn.textContent = btn.id === 'btn-start' ? '🎧 Generate Artifacts' : 'Use Current PDF and Generate';
+            }
+            return;
+        }
+
         // Fallback path for pages where URL doesn't expose the actual PDF.
         if (!payload?.ok || !payload.fileDataBase64) {
             const injected = await chrome.scripting.executeScript({
                 target: { tabId: tab.id },
-                func: async (preferredPdfUrl) => {
+                func: async (preferredPdfUrl, maxPdfBytes) => {
                     const pickCandidateUrl = () => {
                         const embed = document.querySelector('embed[type="application/pdf"]');
                         if (embed?.src) return embed.src;
@@ -786,12 +877,51 @@ async function startPipelineFromCurrentTabPdf(pageUrl, pdfUrl = null, detectedSo
                         if (!response.ok) {
                             return { ok: false, error: `HTTP ${response.status}` };
                         }
-                        const blob = await response.blob();
-                        const mimeType = blob.type || 'application/pdf';
-                        const looksLikePdf = /pdf/i.test(mimeType) || /\.pdf(\?|#|$)/i.test(sourceUrl);
-                        if (!looksLikePdf) {
-                            return { ok: false, error: 'Current tab content is not a PDF' };
+                        const contentLengthHeader = response.headers.get('content-length');
+                        const contentLength = Number(contentLengthHeader);
+                        if (contentLengthHeader !== null && Number.isFinite(contentLength) && contentLength > maxPdfBytes) {
+                            try { await response.body?.cancel?.('PDF exceeds the safe local upload limit'); } catch (_) { /* already closed */ }
+                            return { ok: false, code: 'PDF_TOO_LARGE', error: 'PDF exceeds the safe local upload limit.' };
                         }
+                        if (!response.body?.getReader) {
+                            return { ok: false, code: 'PDF_STREAM_UNAVAILABLE', error: 'PDF response cannot be streamed safely.' };
+                        }
+                        const reader = response.body.getReader();
+                        const chunks = [];
+                        let total = 0;
+                        try {
+                            while (true) {
+                                const { done, value } = await reader.read();
+                                if (done) break;
+                                if (!value?.byteLength) continue;
+                                total += value.byteLength;
+                                if (total > maxPdfBytes) {
+                                    try { await reader.cancel('PDF exceeds the safe local upload limit'); } catch (_) { /* already closed */ }
+                                    return { ok: false, code: 'PDF_TOO_LARGE', error: 'PDF exceeds the safe local upload limit.' };
+                                }
+                                chunks.push(value);
+                            }
+                        } finally {
+                            try { reader.releaseLock(); } catch (_) { /* already released */ }
+                        }
+                        const bytes = new Uint8Array(total);
+                        let offset = 0;
+                        for (const chunk of chunks) {
+                            bytes.set(chunk, offset);
+                            offset += chunk.byteLength;
+                        }
+                        const mimeType = response.headers.get('content-type') || 'application/pdf';
+                        const header = bytes.subarray(0, 1024);
+                        let hasSignature = false;
+                        for (let i = 0; i <= header.length - 5; i += 1) {
+                            if (header[i] === 0x25 && header[i + 1] === 0x50 && header[i + 2] === 0x44 &&
+                                header[i + 3] === 0x46 && header[i + 4] === 0x2d) {
+                                hasSignature = true;
+                                break;
+                            }
+                        }
+                        if (!hasSignature) return { ok: false, error: 'Current tab content is not a valid PDF' };
+                        const blob = new Blob([bytes], { type: mimeType });
                         const fileDataBase64 = await toBase64(blob);
                         return {
                             ok: true,
@@ -804,16 +934,23 @@ async function startPipelineFromCurrentTabPdf(pageUrl, pdfUrl = null, detectedSo
                         return { ok: false, error: e?.message || 'Could not read current PDF from tab' };
                     }
                 },
-                args: [pdfUrl],
+                args: [pdfUrl, MAX_PDF_UPLOAD_BYTES],
             });
             payload = injected?.[0]?.result;
         }
 
         if (!payload?.ok || !payload.fileDataBase64) {
+            if (payload?.code === 'PDF_TOO_LARGE' && /^https?:\/\//i.test(pdfUrl || '')) {
+                console.log('[Popup] PDF is too large for the local bridge; using Gemini Notebook URL import');
+                await startPipeline(pdfUrl, pageUrl || tab.url || pdfUrl, 'pdf', pageTitle);
+                return;
+            }
             if (payload?.error === 'FILE_ACCESS_DISABLED') {
                 showFileAccessHint();
             }
-            throw new Error(payload?.error || 'Could not read current PDF from tab');
+            const error = new Error(payload?.error || 'Could not read current PDF from tab');
+            error.code = payload?.code;
+            throw error;
         }
 
         const selectedTitle = choosePdfTitle({
@@ -824,7 +961,7 @@ async function startPipelineFromCurrentTabPdf(pageUrl, pdfUrl = null, detectedSo
         console.log(`[Popup] Notebook title source: ${selectedTitle.source}`);
 
         if (btn) { btn.textContent = 'Uploading...'; }
-        await chrome.runtime.sendMessage({
+        const response = await chrome.runtime.sendMessage({
             type: 'START_PIPELINE_FILE',
             fileName: payload.fileName || 'local-upload.pdf',
             mimeType: payload.mimeType || 'application/pdf',
@@ -832,8 +969,15 @@ async function startPipelineFromCurrentTabPdf(pageUrl, pdfUrl = null, detectedSo
             pageUrl: pageUrl || payload.sourceUrl || null,
             sourceTitle: selectedTitle.title,
         });
-        await new Promise(r => setTimeout(r, 300));
+        if (!response?.ok) {
+            const error = new Error(response?.message || 'Could not start PDF pipeline');
+            error.code = response?.code;
+            throw error;
+        }
         const state = await getState();
+        if (state.runId !== response.runId || state.status !== 'running') {
+            throw new Error('The PDF pipeline did not retain ownership after starting.');
+        }
         renderProgress(state);
         startPolling();
     } catch (err) {
@@ -841,6 +985,11 @@ async function startPipelineFromCurrentTabPdf(pageUrl, pdfUrl = null, detectedSo
         if (btn) {
             btn.disabled = false;
             btn.textContent = btn.id === 'btn-start' ? '🎧 Generate Artifacts' : 'Use Current PDF and Generate';
+        }
+        if (['PIPELINE_ALREADY_RUNNING', 'PIPELINE_NOT_IDLE', 'PDF_TOO_LARGE'].includes(err?.code) ||
+            /retain ownership/i.test(err?.message || '')) {
+            alert(err?.message || 'Another pipeline is already active.');
+            return;
         }
         promptForPdfUpload(pageUrl);
     }

--- a/runtime-policy.js
+++ b/runtime-policy.js
@@ -8,6 +8,107 @@ const NON_IDEMPOTENT_STEPS = new Set([
   'add_source',
   'generate_artifacts',
 ]);
+const STOPPABLE_STEPS = new Set(['wait_source', 'wait_artifacts']);
+
+export function isActivePipelineRun(state, runId) {
+  return !!runId && state?.status === 'running' && state.runId === runId;
+}
+
+export function canStopPipeline(state, runId = state?.runId) {
+  return isActivePipelineRun(state, runId) && STOPPABLE_STEPS.has(state.step);
+}
+
+export function createPipelineStateCoordinator({ readState, writeState }) {
+  if (typeof readState !== 'function' || typeof writeState !== 'function') {
+    throw new TypeError('readState and writeState functions are required');
+  }
+
+  let queue = Promise.resolve();
+
+  const transact = operation => {
+    const apply = async () => {
+      const current = await readState();
+      const result = await operation(current);
+      if (!result) return { applied: false, state: current };
+
+      const next = result.replace ? result.state : { ...current, ...result.updates };
+      if (result.beforeWrite) await result.beforeWrite(current, next);
+      await writeState(next);
+      let effectError = null;
+      if (result.afterWrite) {
+        try {
+          await result.afterWrite(current, next);
+        } catch (error) {
+          effectError = error;
+        }
+      }
+      return { applied: true, state: next, effectError };
+    };
+    queue = queue.then(apply, apply);
+    return queue;
+  };
+
+  return {
+    update(updates, effects = {}) {
+      return transact(current => ({
+        updates: typeof updates === 'function' ? updates(current) : updates,
+        ...effects,
+      }));
+    },
+
+    replace(state, effects = {}) {
+      return transact(() => ({ replace: true, state, ...effects }));
+    },
+
+    reset(state, effects = {}) {
+      return transact(current => {
+        if (current?.status === 'running') return null;
+        return { replace: true, state, ...effects };
+      });
+    },
+
+    effectWhen(predicate, effect) {
+      return transact(current => {
+        if (!predicate(current)) return null;
+        return { updates: {}, afterWrite: effect };
+      });
+    },
+
+    claim(runId, initialState, effects = {}) {
+      return transact(current => {
+        if (!runId || current?.status !== 'idle') return null;
+        return {
+          replace: true,
+          state: { ...initialState, status: 'running', runId },
+          ...effects,
+        };
+      });
+    },
+
+    transition(runId, updates, { expectedSteps = null, ...effects } = {}) {
+      return transact(current => {
+        if (!isActivePipelineRun(current, runId)) return null;
+        if (expectedSteps && !expectedSteps.includes(current.step)) return null;
+        return {
+          updates: typeof updates === 'function' ? updates(current) : updates,
+          ...effects,
+        };
+      });
+    },
+
+    invalidate(runId, replacement, { expectedSteps = null, ...effects } = {}) {
+      return transact(current => {
+        if (!isActivePipelineRun(current, runId)) return null;
+        if (expectedSteps && !expectedSteps.includes(current.step)) return null;
+        return {
+          replace: true,
+          state: typeof replacement === 'function' ? replacement(current) : replacement,
+          ...effects,
+        };
+      });
+    },
+  };
+}
 
 export function runtimeRecoveryAction(state, hasAlarm) {
   if (!state || state.status !== 'running') {

--- a/scripts/package-store.ps1
+++ b/scripts/package-store.ps1
@@ -12,6 +12,7 @@ $runtimeFiles = @(
     '_locales/ko/messages.json',
     'background.js',
     'content.js',
+    'detection-policy.js',
     'icons/icon16.png',
     'icons/icon48.png',
     'icons/icon128.png',
@@ -20,6 +21,7 @@ $runtimeFiles = @(
     'notebooklm-api.js',
     'offscreen.html',
     'offscreen.js',
+    'pdf-file-policy.js',
     'pdf-metadata.js',
     'popup.html',
     'popup.js',
@@ -35,13 +37,18 @@ foreach ($relativePath in $runtimeFiles) {
 }
 
 New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
-$outputPath = Join-Path $OutputDirectory "scholar-relay-v$($manifest.version)-store.zip"
-$legacyOutputPath = Join-Path $OutputDirectory "chrome-pdf-to-notebooklm-v$($manifest.version)-store.zip"
-if (Test-Path -LiteralPath $legacyOutputPath) {
-    Remove-Item -LiteralPath $legacyOutputPath -Force
-}
-if (Test-Path -LiteralPath $outputPath) {
-    Remove-Item -LiteralPath $outputPath -Force
+$outputPath = Join-Path $OutputDirectory "scholar-relay-v$($manifest.version).zip"
+$checksumPath = "$outputPath.sha256"
+$obsoletePaths = @(
+    (Join-Path $OutputDirectory "scholar-relay-v$($manifest.version)-store.zip"),
+    (Join-Path $OutputDirectory "chrome-pdf-to-notebooklm-v$($manifest.version)-store.zip"),
+    $outputPath,
+    $checksumPath
+)
+foreach ($obsoletePath in $obsoletePaths) {
+    if (Test-Path -LiteralPath $obsoletePath) {
+        Remove-Item -LiteralPath $obsoletePath -Force
+    }
 }
 
 Add-Type -AssemblyName System.IO.Compression
@@ -70,4 +77,18 @@ finally {
     $stream.Dispose()
 }
 
+$sha256 = [Security.Cryptography.SHA256]::Create()
+$zipStream = [IO.File]::OpenRead($outputPath)
+try {
+    $hashBytes = $sha256.ComputeHash($zipStream)
+}
+finally {
+    $zipStream.Dispose()
+    $sha256.Dispose()
+}
+$hash = [BitConverter]::ToString($hashBytes).Replace('-', '').ToLowerInvariant()
+$checksumLine = "$hash  $([IO.Path]::GetFileName($outputPath))`n"
+[IO.File]::WriteAllText($checksumPath, $checksumLine, [Text.UTF8Encoding]::new($false))
+
 Write-Output $outputPath
+Write-Output $checksumPath

--- a/scripts/smoke-extension.mjs
+++ b/scripts/smoke-extension.mjs
@@ -181,6 +181,8 @@ try {
   const chromePath = await resolveChrome();
   chrome = spawn(chromePath, [
     '--disable-gpu',
+    '--enable-unsafe-extension-debugging',
+    ...(process.env.CI ? ['--disable-dev-shm-usage', '--no-sandbox'] : []),
     '--no-first-run',
     '--no-default-browser-check',
     '--window-position=-32000,-32000',

--- a/scripts/smoke-extension.mjs
+++ b/scripts/smoke-extension.mjs
@@ -1,0 +1,237 @@
+import { access, cp, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const tempRoot = await mkdtemp(join(tmpdir(), 'scholar-relay-smoke-'));
+const extensionRoot = join(tempRoot, 'extension');
+const profileDir = join(tempRoot, 'profile');
+const delay = ms => new Promise(resolveDelay => setTimeout(resolveDelay, ms));
+
+async function resolveChrome() {
+  const candidates = [];
+  if (process.env.CHROME_PATH) candidates.push(process.env.CHROME_PATH);
+  if (process.env.LOCALAPPDATA) {
+    const playwrightRoot = join(process.env.LOCALAPPDATA, 'ms-playwright');
+    try {
+      const installs = (await readdir(playwrightRoot, { withFileTypes: true }))
+        .filter(entry => entry.isDirectory() && /^chromium-\d+$/.test(entry.name))
+        .map(entry => entry.name)
+        .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+      for (const install of installs) candidates.push(join(playwrightRoot, install, 'chrome-win64', 'chrome.exe'));
+    } catch {}
+  }
+  candidates.push('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe');
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {}
+  }
+  throw new Error('Chrome was not found. Set CHROME_PATH and retry.');
+}
+
+class CdpSession {
+  constructor(url) {
+    this.socket = new WebSocket(url);
+    this.nextId = 1;
+    this.pending = new Map();
+  }
+
+  async open() {
+    await new Promise((resolveOpen, rejectOpen) => {
+      this.socket.addEventListener('open', resolveOpen, { once: true });
+      this.socket.addEventListener('error', rejectOpen, { once: true });
+    });
+    this.socket.addEventListener('message', event => {
+      const message = JSON.parse(event.data);
+      if (!message.id || !this.pending.has(message.id)) return;
+      const pending = this.pending.get(message.id);
+      this.pending.delete(message.id);
+      if (message.error) pending.reject(new Error(message.error.message));
+      else pending.resolve(message.result);
+    });
+  }
+
+  call(method, params = {}) {
+    const id = this.nextId++;
+    const result = new Promise((resolveCall, reject) => this.pending.set(id, { resolve: resolveCall, reject }));
+    this.socket.send(JSON.stringify({ id, method, params }));
+    return result;
+  }
+
+  close() {
+    this.socket.close();
+  }
+}
+
+async function json(port, path, options) {
+  const response = await fetch(`http://127.0.0.1:${port}${path}`, options);
+  if (!response.ok) throw new Error(`${path} returned HTTP ${response.status}`);
+  return response.json();
+}
+
+async function waitForPort() {
+  const portFile = join(profileDir, 'DevToolsActivePort');
+  for (let attempt = 0; attempt < 150; attempt += 1) {
+    try {
+      const [port] = (await readFile(portFile, 'utf8')).trim().split(/\r?\n/);
+      if (port) return Number(port);
+    } catch {}
+    await delay(100);
+  }
+  throw new Error('Chrome DevTools port did not become available.');
+}
+
+async function findExtensionId(port) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const targets = await json(port, '/json');
+    const worker = targets.find(item => item.type === 'service_worker' && item.url?.endsWith('/background.js'));
+    const id = worker?.url?.match(/^chrome-extension:\/\/([^/]+)/)?.[1];
+    if (id) return id;
+    await delay(100);
+  }
+  throw new Error('Loaded extension service worker was not found.');
+}
+
+async function openTarget(port, url) {
+  const target = await json(port, `/json/new?${encodeURIComponent(url)}`, { method: 'PUT' });
+  const session = new CdpSession(target.webSocketDebuggerUrl);
+  await session.open();
+  await session.call('Page.enable');
+  await session.call('Runtime.enable');
+  return session;
+}
+
+async function evaluate(session, expression) {
+  const result = await session.call('Runtime.evaluate', { expression, awaitPromise: true, returnByValue: true });
+  if (result.exceptionDetails) {
+    throw new Error(result.exceptionDetails.exception?.description || result.exceptionDetails.text || 'Evaluation failed');
+  }
+  return result.result?.value;
+}
+
+async function reload(session) {
+  await session.call('Page.reload', { ignoreCache: true });
+  await delay(500);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const server = createServer((request, response) => {
+  if (request.url === '/paper.pdf' || request.url === '/paper-two.pdf') {
+    response.writeHead(200, { 'content-type': 'application/pdf' });
+    response.end('%PDF-1.7\n%%EOF');
+    return;
+  }
+  if (request.url === '/article' || request.url === '/article-next') {
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    response.end('<!doctype html><title>Article</title><a id="pdf-link" href="/paper.pdf">Download PDF</a>');
+    return;
+  }
+  response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+  response.end('<!doctype html><title>Ordinary page</title><h1>No PDF here</h1>');
+});
+await new Promise((resolveListen, rejectListen) => {
+  server.once('error', rejectListen);
+  server.listen(0, '127.0.0.1', resolveListen);
+});
+const serverPort = server.address().port;
+const origin = `http://127.0.0.1:${serverPort}`;
+
+let chrome;
+let popup;
+try {
+  await cp(sourceRoot, extensionRoot, {
+    recursive: true,
+    filter: source => !source.includes(`${join(sourceRoot, '.git')}`) &&
+      !source.includes(`${join(sourceRoot, 'dist')}`),
+  });
+  const manifestPath = join(extensionRoot, 'manifest.json');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  manifest.host_permissions.push(`${origin}/*`);
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  const chromePath = await resolveChrome();
+  chrome = spawn(chromePath, [
+    '--disable-gpu',
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--window-position=-32000,-32000',
+    '--remote-debugging-port=0',
+    `--user-data-dir=${profileDir}`,
+    `--disable-extensions-except=${extensionRoot}`,
+    `--load-extension=${extensionRoot}`,
+  ], { windowsHide: true, stdio: 'ignore' });
+
+  const devtoolsPort = await waitForPort();
+  const extensionId = await findExtensionId(devtoolsPort);
+  popup = await openTarget(devtoolsPort, `chrome-extension://${extensionId}/popup.html`);
+  await delay(400);
+
+  const tabA = await evaluate(popup, `chrome.tabs.create({url:${JSON.stringify(`${origin}/article`)},active:true})`);
+  await delay(300);
+  await reload(popup);
+  let view = await evaluate(popup, `({text:document.getElementById('content').innerText,hasStart:!!document.getElementById('btn-start')})`);
+  assert(view.hasStart && view.text.includes('/paper.pdf'), 'Linked PDF was not detected in the article tab');
+  let cachedDetection = await evaluate(popup, `chrome.storage.local.get('detectedPdf').then(result=>result.detectedPdf)`);
+  assert(cachedDetection?.tabId === tabA.id, 'Content detection was not bound to its sender tab');
+  assert(cachedDetection?.tabUrl === `${origin}/article`, 'Content detection stored the wrong sender URL');
+
+  await evaluate(popup, `chrome.tabs.create({url:${JSON.stringify(`${origin}/plain`)},active:true})`);
+  await delay(300);
+  await reload(popup);
+  view = await evaluate(popup, `({text:document.getElementById('content').innerText,hasUrl:!!document.getElementById('btn-start-url')})`);
+  assert(view.hasUrl, 'Ordinary tab did not render the webpage fallback');
+  assert(!view.text.includes('/paper.pdf'), 'A stale PDF leaked into another tab');
+
+  await evaluate(popup, `chrome.scripting.executeScript({target:{tabId:${tabA.id}},func:()=>{history.pushState({},'', '/article-next');document.getElementById('pdf-link').href='/paper-two.pdf';}})`);
+  await evaluate(popup, `chrome.tabs.update(${tabA.id},{active:true})`);
+  await delay(300);
+  await reload(popup);
+  view = await evaluate(popup, `({text:document.getElementById('content').innerText,hasStart:!!document.getElementById('btn-start')})`);
+  assert(view.hasStart && view.text.includes('/paper-two.pdf'), 'SPA navigation did not refresh the detected PDF');
+  assert(!view.text.includes(`${origin}/paper.pdf`), 'A stale PDF survived navigation in the same tab');
+
+  const errorText = 'Smoke test visible pipeline error';
+  await evaluate(popup, `chrome.storage.local.set({pipelineState:{status:'error',runId:'smoke',step:'error',stepDetail:${JSON.stringify(errorText)},error:${JSON.stringify(errorText)},pdfUrl:'smoke.pdf',tasks:[]}})`);
+  await reload(popup);
+  view = await evaluate(popup, `document.querySelector('.pipeline-error-box')?.innerText`);
+  assert(view === errorText, 'Pipeline error was not visibly rendered');
+
+  await evaluate(popup, `chrome.storage.local.set({pipelineState:{status:'running',runId:'existing-run',step:'auth',stepDetail:'Busy',pdfUrl:'busy.pdf',tasks:[]}})`);
+  const busyResponse = await evaluate(popup, `chrome.runtime.sendMessage({type:'START_PIPELINE',pdfUrl:${JSON.stringify(`${origin}/plain`)},pageUrl:${JSON.stringify(`${origin}/plain`)},sourceType:'webpage'})`);
+  assert(busyResponse?.ok === false && busyResponse?.code === 'PIPELINE_ALREADY_RUNNING', 'A second pipeline start was not rejected');
+  let storedState = await evaluate(popup, `chrome.storage.local.get('pipelineState').then(result=>result.pipelineState)`);
+  assert(storedState.runId === 'existing-run', 'A rejected start replaced the active run');
+
+  await evaluate(popup, `chrome.storage.local.set({pipelineState:{status:'running',runId:'stoppable-run',step:'wait_source',stepDetail:'Waiting',pdfUrl:'wait.pdf',tasks:[]}})`);
+  const staleStop = await evaluate(popup, `chrome.runtime.sendMessage({type:'ABORT_PIPELINE',runId:'old-run'})`);
+  assert(staleStop?.ok === false, 'A stale popup stopped a replacement run');
+  const acceptedStop = await evaluate(popup, `chrome.runtime.sendMessage({type:'ABORT_PIPELINE',runId:'stoppable-run'})`);
+  assert(acceptedStop?.ok === true, 'The matching polling run could not be stopped');
+  storedState = await evaluate(popup, `chrome.storage.local.get('pipelineState').then(result=>result.pipelineState)`);
+  assert(storedState.status === 'idle' && storedState.runId === null, 'Stopped run did not return to idle state');
+
+  console.log('Chrome extension smoke test passed.');
+} finally {
+  popup?.close();
+  if (chrome) {
+    chrome.kill();
+    if (chrome.exitCode === null) {
+      await Promise.race([new Promise(resolveExit => chrome.once('exit', resolveExit)), delay(3000)]);
+    }
+  }
+  await new Promise(resolveClose => server.close(resolveClose));
+  const safeTempRoot = resolve(tmpdir());
+  const resolvedTemp = resolve(tempRoot);
+  if (!resolvedTemp.startsWith(`${safeTempRoot}\\`) || !resolvedTemp.includes('scholar-relay-smoke-')) {
+    throw new Error(`Refusing to remove unexpected temporary path: ${resolvedTemp}`);
+  }
+  await rm(resolvedTemp, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
+}

--- a/scripts/smoke-extension.mjs
+++ b/scripts/smoke-extension.mjs
@@ -1,7 +1,7 @@
 import { access, cp, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 
@@ -251,7 +251,7 @@ try {
   await new Promise(resolveClose => server.close(resolveClose));
   const safeTempRoot = resolve(tmpdir());
   const resolvedTemp = resolve(tempRoot);
-  if (!resolvedTemp.startsWith(`${safeTempRoot}\\`) || !resolvedTemp.includes('scholar-relay-smoke-')) {
+  if (dirname(resolvedTemp) !== safeTempRoot || !basename(resolvedTemp).startsWith('scholar-relay-smoke-')) {
     throw new Error(`Refusing to remove unexpected temporary path: ${resolvedTemp}`);
   }
   await rm(resolvedTemp, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });

--- a/scripts/smoke-extension.mjs
+++ b/scripts/smoke-extension.mjs
@@ -92,6 +92,14 @@ async function findExtensionId(port) {
     const worker = targets.find(item => item.type === 'service_worker' && item.url?.endsWith('/background.js'));
     const id = worker?.url?.match(/^chrome-extension:\/\/([^/]+)/)?.[1];
     if (id) return id;
+    try {
+      const preferences = JSON.parse(await readFile(join(profileDir, 'Default', 'Preferences'), 'utf8'));
+      const settings = preferences.extensions?.settings || {};
+      for (const [extensionId, value] of Object.entries(settings)) {
+        if (value?.path && resolve(value.path) === extensionRoot) return extensionId;
+        if (value?.manifest?.name === 'ScholarRelay') return extensionId;
+      }
+    } catch {}
     await delay(100);
   }
   throw new Error('Loaded extension service worker was not found.');

--- a/scripts/smoke-extension.mjs
+++ b/scripts/smoke-extension.mjs
@@ -122,6 +122,19 @@ async function evaluate(session, expression) {
   return result.result?.value;
 }
 
+async function waitForExtensionPage(session) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      const ready = await evaluate(session, `location.protocol === 'chrome-extension:' && document.readyState === 'complete' && typeof chrome?.tabs?.create === 'function'`);
+      if (ready) return;
+    } catch {}
+    await delay(100);
+  }
+  const state = await evaluate(session, `({href:location.href,readyState:document.readyState,hasChrome:typeof chrome !== 'undefined',hasTabs:typeof chrome?.tabs !== 'undefined'})`)
+    .catch(error => ({ evaluationError: error.message }));
+  throw new Error(`Extension popup did not become ready: ${JSON.stringify(state)}`);
+}
+
 async function reload(session) {
   await session.call('Page.reload', { ignoreCache: true });
   await delay(500);
@@ -180,7 +193,7 @@ try {
   const devtoolsPort = await waitForPort();
   const extensionId = await findExtensionId(devtoolsPort);
   popup = await openTarget(devtoolsPort, `chrome-extension://${extensionId}/popup.html`);
-  await delay(400);
+  await waitForExtensionPage(popup);
 
   const tabA = await evaluate(popup, `chrome.tabs.create({url:${JSON.stringify(`${origin}/article`)},active:true})`);
   await delay(300);

--- a/tests/safety-policy.test.js
+++ b/tests/safety-policy.test.js
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  bindDetectionToTab,
+  detectionMatchesTab,
+  directDetectionMatchesTab,
+} from '../detection-policy.js';
+import {
+  MAX_PDF_UPLOAD_BYTES,
+  assertPdfUploadSize,
+  decodedBase64ByteLength,
+  hasBase64PdfSignature,
+  hasPdfSignature,
+  readResponseWithinLimit,
+} from '../pdf-file-policy.js';
+import {
+  canStopPipeline,
+  createPipelineStateCoordinator,
+} from '../runtime-policy.js';
+
+test('cached PDF detection is accepted only for the exact tab and URL', () => {
+  const tab = { id: 7, url: 'https://example.org/article' };
+  const detection = bindDetectionToTab({
+    isPdf: true,
+    pdfUrl: 'https://example.org/paper.pdf',
+    pageUrl: tab.url,
+  }, tab);
+
+  assert.equal(detectionMatchesTab(detection, tab), true);
+  assert.equal(detectionMatchesTab(detection, { ...tab, id: 8 }), false);
+  assert.equal(detectionMatchesTab(detection, { ...tab, url: 'https://example.org/other' }), false);
+  assert.equal(detectionMatchesTab({ ...detection, tabId: undefined }, tab), false);
+  assert.equal(directDetectionMatchesTab(detection, tab), true);
+  assert.equal(directDetectionMatchesTab({ ...detection, pageUrl: 'https://example.org/old' }, tab), false);
+});
+
+test('PDF size and base64 guards enforce a bounded local bridge', () => {
+  assert.equal(assertPdfUploadSize(MAX_PDF_UPLOAD_BYTES), MAX_PDF_UPLOAD_BYTES);
+  assert.throws(
+    () => assertPdfUploadSize(MAX_PDF_UPLOAD_BYTES + 1),
+    error => error?.code === 'PDF_TOO_LARGE' && /32 MiB/.test(error.message)
+  );
+  assert.equal(decodedBase64ByteLength('TQ=='), 1);
+  assert.equal(decodedBase64ByteLength('TWE='), 2);
+  assert.equal(decodedBase64ByteLength('TWFu'), 3);
+});
+
+test('PDF signature validation rejects renamed non-PDF content', () => {
+  const pdf = new TextEncoder().encode('\n%PDF-1.7\nexample');
+  const html = new TextEncoder().encode('<!doctype html><title>Error</title>');
+  assert.equal(hasPdfSignature(pdf), true);
+  assert.equal(hasPdfSignature(html), false);
+  assert.equal(hasBase64PdfSignature(Buffer.from(pdf).toString('base64')), true);
+  assert.equal(hasBase64PdfSignature(Buffer.from(html).toString('base64')), false);
+});
+
+test('streaming PDF reads stop before an unbounded response is allocated', async () => {
+  const response = new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1, 2, 3]));
+      controller.enqueue(new Uint8Array([4, 5]));
+      controller.close();
+    },
+  }));
+  assert.deepEqual([...await readResponseWithinLimit(response, 5)], [1, 2, 3, 4, 5]);
+
+  const oversized = new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1, 2, 3]));
+      controller.enqueue(new Uint8Array([4, 5, 6]));
+      controller.close();
+    },
+  }));
+  await assert.rejects(
+    () => readResponseWithinLimit(oversized, 5),
+    error => error?.code === 'PDF_TOO_LARGE'
+  );
+});
+
+test('serialized pipeline claims allow exactly one active run', async () => {
+  let state = { status: 'idle', runId: null };
+  const coordinator = createPipelineStateCoordinator({
+    readState: async () => state,
+    writeState: async next => { state = next; },
+  });
+
+  const [first, second] = await Promise.all([
+    coordinator.claim('run-a', { status: 'running', runId: 'run-a', step: 'auth' }),
+    coordinator.claim('run-b', { status: 'running', runId: 'run-b', step: 'auth' }),
+  ]);
+  assert.equal(Number(first.applied) + Number(second.applied), 1);
+  assert.equal(state.status, 'running');
+});
+
+test('a post-commit effect failure cannot erase committed run ownership', async () => {
+  let state = { status: 'idle', runId: null };
+  const coordinator = createPipelineStateCoordinator({
+    readState: async () => state,
+    writeState: async next => { state = next; },
+  });
+  const result = await coordinator.claim('run-a', {
+    status: 'running', runId: 'run-a', step: 'auth',
+  }, {
+    afterWrite: async () => { throw new Error('badge unavailable'); },
+  });
+  assert.equal(result.applied, true);
+  assert.equal(result.effectError?.message, 'badge unavailable');
+  assert.equal(state.runId, 'run-a');
+});
+
+test('inactive alarm cleanup finishes before a replacement run can claim state', async () => {
+  let state = { status: 'idle', runId: null };
+  const order = [];
+  let releaseCleanup;
+  const coordinator = createPipelineStateCoordinator({
+    readState: async () => state,
+    writeState: async next => { state = next; },
+  });
+  const cleanup = coordinator.effectWhen(
+    current => current.status !== 'running',
+    () => new Promise(resolve => {
+      order.push('cleanup-start');
+      releaseCleanup = () => { order.push('cleanup-end'); resolve(); };
+    })
+  );
+  const claim = coordinator.claim('run-b', {
+    status: 'running', runId: 'run-b', step: 'auth',
+  }).then(result => { order.push('claim'); return result; });
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.deepEqual(order, ['cleanup-start']);
+  releaseCleanup();
+  assert.equal((await cleanup).applied, true);
+  assert.equal((await claim).applied, true);
+  assert.deepEqual(order, ['cleanup-start', 'cleanup-end', 'claim']);
+});
+
+test('stale pipeline work cannot update or stop a replacement run', async () => {
+  let state = { status: 'idle', runId: null };
+  let staleEffectRan = false;
+  const coordinator = createPipelineStateCoordinator({
+    readState: async () => state,
+    writeState: async next => { state = next; },
+  });
+
+  assert.equal((await coordinator.claim('run-a', {
+    status: 'running', runId: 'run-a', step: 'wait_source',
+  })).applied, true);
+  assert.equal(canStopPipeline(state, 'run-a'), true);
+  assert.equal((await coordinator.invalidate('run-a', { status: 'idle', runId: null }, {
+    expectedSteps: ['wait_source'],
+  })).applied, true);
+  assert.equal((await coordinator.claim('run-b', {
+    status: 'running', runId: 'run-b', step: 'auth',
+  })).applied, true);
+
+  const stale = await coordinator.transition('run-a', { step: 'wait_artifacts' }, {
+    afterWrite: async () => { staleEffectRan = true; },
+  });
+  assert.equal(stale.applied, false);
+  assert.equal(staleEffectRan, false);
+  assert.equal(state.runId, 'run-b');
+  assert.equal((await coordinator.reset({ status: 'idle', runId: null })).applied, false);
+});
+
+test('only polling phases expose cooperative stop behavior', () => {
+  for (const step of ['wait_source', 'wait_artifacts']) {
+    assert.equal(canStopPipeline({ status: 'running', runId: 'run-a', step }, 'run-a'), true);
+  }
+  for (const step of ['auth', 'create_notebook', 'add_source', 'generate_artifacts']) {
+    assert.equal(canStopPipeline({ status: 'running', runId: 'run-a', step }, 'run-a'), false);
+  }
+  assert.equal(canStopPipeline({ status: 'running', runId: 'run-b', step: 'wait_source' }, 'run-a'), false);
+});

--- a/tests/store-readiness.test.js
+++ b/tests/store-readiness.test.js
@@ -6,6 +6,7 @@ import {
   PIPELINE_ALARM_NAME,
   PIPELINE_POLL_PERIOD_MINUTES,
   createExclusiveRunner,
+  canStopPipeline,
   interruptedPipelineUpdate,
   pollingElapsedMs,
   runtimeRecoveryAction,
@@ -62,7 +63,11 @@ test('ScholarRelay branding, package identity, and localized store copy stay ali
   assert.match(privacyText, /^# Privacy Policy for ScholarRelay/m);
   assert.match(listingText, /## English listing/);
   assert.match(listingText, /## 한국어 스토어 등록 문구/);
-  assert.match(packageScript, /scholar-relay-v\$\(\$manifest\.version\)-store\.zip/);
+  assert.match(packageScript, /scholar-relay-v\$\(\$manifest\.version\)\.zip/);
+  assert.doesNotMatch(packageScript, /\$outputPath\s*=.*-store\.zip/);
+  assert.match(packageScript, /\$checksumPath = "\$outputPath\.sha256"/);
+  assert.match(packageScript, /detection-policy\.js/);
+  assert.match(packageScript, /pdf-file-policy\.js/);
   assert.match(packageScript, /_locales\/en\/messages\.json/);
   assert.match(packageScript, /_locales\/ko\/messages\.json/);
 });
@@ -86,6 +91,13 @@ test('runtime recovery stops interrupted non-idempotent phases', () => {
   assert.equal(update.status, 'error');
   assert.match(update.error, /avoid duplicate notebooks or artifacts/i);
   assert.match(update.error, /Open the existing notebook/i);
+});
+
+test('pipeline stop is limited to the matching run in polling phases', () => {
+  assert.equal(canStopPipeline({ status: 'running', runId: 'a', step: 'wait_source' }, 'a'), true);
+  assert.equal(canStopPipeline({ status: 'running', runId: 'a', step: 'wait_artifacts' }, 'a'), true);
+  assert.equal(canStopPipeline({ status: 'running', runId: 'a', step: 'generate_artifacts' }, 'a'), false);
+  assert.equal(canStopPipeline({ status: 'running', runId: 'b', step: 'wait_source' }, 'a'), false);
 });
 
 test('delayed alarm timing preserves the original wall-clock timeout', () => {


### PR DESCRIPTION
## Summary

- bind PDF detections to the exact tab and URL, including SPA refreshes
- serialize pipeline ownership and reject stale starts, stops, alarms, and state writes
- preserve accepted remote work while stopping later mutations after cancellation
- bound local PDF transfer memory at 32 MiB and validate PDF signatures
- surface pipeline errors and make popup failure paths recoverable
- add deterministic safety tests, a real Chrome smoke test, and pinned Windows CI
- produce one canonical release ZIP with an exact SHA-256 sidecar

## Validation

- `npm test` with 51 passing tests
- `npm run smoke:chrome`
- JavaScript syntax and JSON parsing checks
- `git diff --check`
- `npm run package:store`
- exact 19-file archive allowlist, embedded version, checksum, and source-byte identity