### PR TITLE
Prepare ScholarRelay v1.2.2 store resubmission

### DIFF
--- a/docs/chrome-web-store-listing.md
+++ b/docs/chrome-web-store-listing.md
@@ -1,6 +1,6 @@
 # Chrome Web Store Listing Package
 
-Prepared for ScholarRelay 1.2.1. Confirm every field against the final uploaded ZIP before submission.
+Prepared for ScholarRelay 1.2.2. Confirm every field against the final uploaded ZIP before submission.
 
 ## Product identity
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "minimum_chrome_version": "120",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scholar-relay",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/store-readiness.test.js
+++ b/tests/store-readiness.test.js
@@ -23,7 +23,7 @@ test('store manifest uses minimum permissions and a production-safe alarm baseli
   assert.equal(manifest.name, '__MSG_extensionName__');
   assert.equal(manifest.description, '__MSG_extensionDescription__');
   assert.equal(manifest.default_locale, 'en');
-  assert.equal(manifest.version, '1.2.1');
+  assert.equal(manifest.version, '1.2.2');
   assert.equal(manifest.minimum_chrome_version, '120');
   assert.equal(manifest.permissions.includes('cookies'), false);
   assert.equal(manifest.host_permissions.includes('*://*/*'), false);


### PR DESCRIPTION
## Summary

- bump the finalized store package to 1.2.2
- align package metadata and the store listing preparation note
- preserve the historical v1.2.1 filename-transition documentation

## Validation

- npm test, 51 passing
- npm run smoke:chrome
- npm run package:store
- 19-file allowlist, embedded manifest 1.2.2, checksum sidecar, and extracted byte identity verified