### PR TITLE
Recover confirmed PDF import failures with one upload fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
             'popup.html',
             'popup.js',
             'runtime-policy.js',
+            'source-import.js',
             'site-permissions.js'
           ) | Sort-Object
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# ScholarRelay maintenance
+
+Read [development history](docs/DEVELOPMENT.md) for the reasons behind existing behavior.
+
+- Keep issues and PRs compact and in English. State the problem, resulting behavior, and relevant validation. Link the closing issue.
+- Use plain punctuation. Do not use em dashes. Minimize colons and semicolons in prose.
+- Write equivalent Korean and English release notes. Keep current README and store descriptions consistent with shipped behavior.
+- Prefer HTML metadata and URL import. Download PDFs only when needed. Keep transfers bounded and validate PDF signatures.
+- A timeout or malformed mutation response is an unknown outcome. Reconcile with reads and never blindly replay source creation, uploads, or artifact generation.
+- Preserve run ownership, cancellation, and restart safeguards. Use focused behavioral tests and the existing release gates.
+- Merge only after CI passes for the exact PR head. Run merged-main CI before releasing. Align manifest and package versions.
+- Verify the ZIP allowlist, embedded version, extracted file bytes, and SHA-256. Publish and submit the same ZIP to the existing Chrome Web Store item.
+- Record submitted version, digest, and dashboard status. Pending review is not publication. Verify the public listing after approval.
+- Keep unrelated issues and user changes outside the current task. Do not add approval checkpoints to already authorized work.

--- a/background.js
+++ b/background.js
@@ -66,6 +66,7 @@ import {
     pollingElapsedMs,
     runtimeRecoveryAction,
 } from './runtime-policy.js';
+import { createPdfFallback, canFallback, isConfirmedImportRejection } from './source-import.js';
 import { bindDetectionToTab } from './detection-policy.js';
 import {
     MAX_PDF_UPLOAD_BYTES,
@@ -97,6 +98,13 @@ const INITIAL_STATE = {
     notebookUrl: null,
     notebookTitle: null,
     sourceId: null,
+    importMethod: null,
+    originalPdfUrl: null,
+    pdfEvidence: null,
+    fallbackAttempted: false,
+    fallbackUploadStarted: false,
+    failedUrlSourceId: null,
+    replacementSourceId: null,
     collectionAssignment: null, // { collectionId, name, status, error? }
     tasks: [],               // [{ type, taskId, status }] for each artifact being generated
     error: null,
@@ -705,6 +713,10 @@ async function tickSourcePoll(state) {
     }
 
     if (source.status === SourceStatus.ERROR) {
+        if (canFallback(state)) {
+            await fallbackPdf(runId);
+            return;
+        }
         await failPipeline(runId, `${sourceLabel} processing failed.`, state.notebookId);
         return;
     }
@@ -1034,6 +1046,9 @@ async function reconcilePipelineRuntime() {
             setBadge('!', '#e03e3e').catch(badgeError => console.warn('[Badge] Recovery badge failed:', badgeError));
             console.warn('[Recovery] Could not restore polling alarm:', error);
         }
+    } else if (action === 'wait_pdf_access') {
+        await setState({ step: 'wait_pdf_access', stepDetail: 'PDF download was paused. Open the popup to resume or select a PDF.' });
+        await chrome.alarms.clear(ALARM_NAME);
     } else if (action === 'clear_alarm') {
         await chrome.alarms.clear(ALARM_NAME);
     } else if (action === 'interrupt') {
@@ -1042,6 +1057,29 @@ async function reconcilePipelineRuntime() {
         setBadge('!', '#e03e3e').catch(error => console.warn('[Badge] Recovery badge failed:', error));
         console.warn(`[Recovery] Stopped interrupted non-idempotent phase: ${state?.step}`);
     }
+}
+
+const fallbackPdf = createPdfFallback({
+    getState,
+    transition: transitionRun,
+    download: downloadRemotePdfForUpload,
+    upload: (notebookId, file) => addFileSource(notebookId, file.filename, file.fileData, file.mimeType),
+    poll: () => chrome.alarms.create(ALARM_NAME, { periodInMinutes: PIPELINE_POLL_PERIOD_MINUTES }),
+    fail: failPipeline,
+});
+
+async function resumePdfFallback(message) {
+    await bootReconciliationPromise;
+    await requireActiveRun(message.runId, ['wait_pdf_access']);
+    let file = null;
+    if (message.fileDataBase64) {
+        assertPdfUploadSize(decodedBase64ByteLength(message.fileDataBase64));
+        if (!hasBase64PdfSignature(message.fileDataBase64)) throw new Error('The selected file is not a PDF.');
+        file = { filename: message.fileName || 'paper.pdf', fileData: message.fileDataBase64, mimeType: 'application/pdf' };
+    }
+    // Keep the message channel alive until the claimed fallback completes.
+    await fallbackPdf(message.runId, { resume: true, file });
+    return { ok: true, state: await getState() };
 }
 
 const bootReconciliationPromise = reconcilePipelineRuntime()
@@ -1110,38 +1148,16 @@ async function runPipeline(runId, pdfUrl, pageUrl, uploadFile = null, sourceType
             if (typeof pdfUrl === 'string' && pdfUrl.startsWith('file://')) {
                 throw new Error('Local PDF detected. Use local upload mode instead of URL mode.');
             }
-            const canFallbackToPdfUpload = !isWebpageSourceType(effectiveSourceType) && isLikelyPdfUrl(pdfUrl);
             try {
                 await requireActiveRun(runId, ['add_source']);
                 sourceMutationStarted = true;
                 source = await addUrlSource(notebook.id, pdfUrl);
             } catch (urlErr) {
-                if (urlErr?.code === 'PIPELINE_STALE_RUN') throw urlErr;
-                if (!canFallbackToPdfUpload) {
-                    throw urlErr;
+                if (isConfirmedImportRejection(urlErr) && canFallback(await getState())) {
+                    await fallbackPdf(runId);
+                    return;
                 }
-                console.warn('[Pipeline] URL source add failed, trying download+upload fallback:', urlErr?.message || urlErr);
-                await transitionRun(runId, {
-                    stepDetail: 'URL source was blocked. Downloading PDF from the current URL and uploading directly...'
-                }, { expectedSteps: ['add_source'] });
-
-                try {
-                    const fallbackFile = await downloadRemotePdfForUpload(pdfUrl, pageUrl);
-                    await requireActiveRun(runId, ['add_source']);
-                    source = await addFileSource(
-                        notebook.id,
-                        fallbackFile.filename,
-                        fallbackFile.fileData,
-                        fallbackFile.mimeType
-                    );
-                    await requireActiveRun(runId, ['add_source']);
-                    await transitionRun(runId, {
-                        stepDetail: `URL blocked. Fallback upload succeeded (${fallbackFile.filename}).`
-                    }, { expectedSteps: ['add_source'] });
-                } catch (fallbackErr) {
-                    if (fallbackErr?.code === 'PIPELINE_STALE_RUN') throw fallbackErr;
-                    throw new Error(buildFallbackUploadErrorMessage(urlErr, fallbackErr, pdfUrl));
-                }
+                throw urlErr;
             }
         }
 
@@ -1206,6 +1222,9 @@ async function startPipelineRequest(message, uploadFile = null) {
         sourceType,
         pageUrl: message.pageUrl || null,
         sourceTitle: normalizeSourceTitle(message.sourceTitle) || null,
+        importMethod: uploadFile ? 'file' : 'url',
+        originalPdfUrl: uploadFile ? null : message.pdfUrl,
+        pdfEvidence: message.pdfEvidence || null,
         startedAt: new Date().toISOString(),
         stepStartedAt: new Date().toISOString(),
     };
@@ -1258,7 +1277,7 @@ async function stopPipelineRequest(requestedRunId) {
         stepDetail: 'Monitoring stopped. No further work will be started.',
     };
     const stopped = await pipelineState.invalidate(requestedRunId, replacement, {
-        expectedSteps: ['wait_source', 'wait_artifacts'],
+        expectedSteps: ['wait_source', 'wait_artifacts', 'wait_pdf_access', 'download_pdf'],
         afterWrite: async () => {
             await chrome.alarms.clear(ALARM_NAME);
         },
@@ -1277,6 +1296,12 @@ async function stopPipelineRequest(requestedRunId) {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.type === 'RESUME_PDF_FALLBACK') {
+        resumePdfFallback(message).then(sendResponse)
+            .catch(error => sendResponse({ ok: false, code: error.code, message: error.message }));
+        return true;
+    }
+
     if (message.type === 'START_PIPELINE') {
         startPipelineRequest(message)
             .then(sendResponse)

--- a/notebooklm-api.js
+++ b/notebooklm-api.js
@@ -362,7 +362,10 @@ function extractRpcResult(chunks, rpcId) {
       // Check for error
       if (item[0] === 'er' && item[1] === rpcId) {
         const errorCode = item.length > 2 ? item[2] : null;
-        throw new Error(`RPC error for ${rpcId}: code=${errorCode}`);
+        const error = new Error(`RPC error for ${rpcId}: code=${errorCode}`);
+        error.code = 'RPC_REJECTED';
+        error.rpcCode = errorCode;
+        throw error;
       }
 
       // Check for success
@@ -602,7 +605,9 @@ async function rpcCall(methodId, params, sourcePath = '/', allowNull = false) {
     }
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      const error = new Error(`HTTP ${response.status}: ${response.statusText}`);
+      error.httpStatus = response.status;
+      throw error;
     }
 
     return decodeResponse(responseText, methodId, allowNull);
@@ -890,7 +895,18 @@ async function addUrlSource(notebookId, url) {
       RPCMethod.ADD_SOURCE, params,
       `/notebook/${notebookId}`
     );
-  } catch (error) {
+    const id = extractFirstIdFromResult(result);
+    if (!id) throw mutationUncertainError(RPCMethod.ADD_SOURCE, 'The response did not identify a source.');
+    return { id, title: null };
+  } catch (caught) {
+    let error = caught;
+    if ([400, 422].includes(error?.httpStatus) || (error?.code === 'RPC_REJECTED' && error.rpcCode === 3)) {
+      error.code = 'SOURCE_IMPORT_REJECTED';
+      throw error;
+    }
+    if (/No result found for RPC ID|Unexpected token/.test(error?.message || '')) {
+      error = mutationUncertainError(RPCMethod.ADD_SOURCE, 'The source response could not be decoded.');
+    }
     if (error?.code !== 'TRANSIENT_MUTATION_UNCERTAIN') throw error;
 
     // The server can commit an ADD_SOURCE mutation while its streaming response
@@ -924,20 +940,7 @@ async function addUrlSource(notebookId, url) {
     throw error;
   }
 
-  // Parse source from response (shape can drift over time)
-  let sourceId = extractFirstIdFromResult(result);
-  let sourceTitle = null;
-  if (Array.isArray(result)) {
-    if (!sourceId && Array.isArray(result[0])) {
-      sourceId = Array.isArray(result[0][0]) ? result[0][0][0] : result[0][0];
-    }
-    if (result.length > 1) {
-      sourceTitle = result[1];
-    }
-  }
 
-  console.log(`[NotebookLM API] Added source: ${sourceId} (${sourceTitle})`);
-  return { id: sourceId, title: sourceTitle };
 }
 
 /**

--- a/popup.js
+++ b/popup.js
@@ -19,7 +19,7 @@ const contentEl = document.getElementById('content');
 // Pipeline steps -- 'keys' maps one or more background state step names to this display row
 const STEPS = [
     { keys: ['auth', 'create_notebook'], label: 'Setup', emoji: '🔑' },
-    { keys: ['add_source'], label: 'Add Source', emoji: '📄' },
+    { keys: ['add_source', 'download_pdf', 'upload_pdf', 'wait_pdf_access'], label: 'Add Source', emoji: '📄' },
     { keys: ['wait_source'], label: 'Processing Source', emoji: '⏳' },
     {
         keys: ['generate_artifacts',
@@ -530,7 +530,11 @@ function renderProgress(state) {
     if (state.status === 'error') {
         bottomHtml += `<div class="pipeline-error-box" role="alert">${escapeHtml(state.error || state.stepDetail || 'The pipeline failed.')}</div>`;
     }
-    if (state.status === 'running' && ['wait_source', 'wait_artifacts'].includes(state.step)) {
+    if (state.status === 'running' && state.step === 'wait_pdf_access') {
+        bottomHtml += `<button class="btn-generate" id="btn-resume-pdf">Allow PDF Download and Retry</button>
+          <button class="btn-secondary" id="btn-fallback-file">Choose PDF for This Notebook</button>`;
+    }
+    if (state.status === 'running' && ['wait_source', 'wait_artifacts', 'wait_pdf_access', 'download_pdf'].includes(state.step)) {
         bottomHtml += `<button class="btn-secondary" id="btn-abort">Stop Monitoring</button>`;
     }
     if (state.status === 'error' || state.status === 'completed') {
@@ -560,6 +564,37 @@ function renderProgress(state) {
         }
     });
     document.getElementById('btn-abort')?.addEventListener('click', () => abortPipeline(state.runId));
+    document.getElementById('btn-resume-pdf')?.addEventListener('click', async () => {
+        try {
+            const pattern = httpOriginPattern(state.originalPdfUrl);
+            if (!pattern || !await chrome.permissions.request({ origins: [pattern] })) return;
+            await resumeFallbackFromPopup(state.runId);
+        } catch (error) { alert(error.message); }
+    });
+    document.getElementById('btn-fallback-file')?.addEventListener('click', () => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = '.pdf,application/pdf';
+        input.addEventListener('change', async () => {
+            try {
+                const file = input.files?.[0];
+                if (!file) return;
+                assertPdfUploadSize(file.size);
+                if (!hasPdfSignature(await file.slice(0, 1024).arrayBuffer())) throw new Error('The selected file is not a PDF.');
+                await resumeFallbackFromPopup(state.runId, {
+                    fileName: file.name, fileDataBase64: await readFileAsBase64(file),
+                });
+            } catch (error) { alert(error.message); }
+        });
+        input.click();
+    });
+}
+
+async function resumeFallbackFromPopup(runId, file = {}) {
+    const response = await chrome.runtime.sendMessage({ type: 'RESUME_PDF_FALLBACK', runId, ...file });
+    if (!response?.ok) throw new Error(response?.message || 'Could not resume PDF upload.');
+    renderProgress(response.state);
+    if (response.state.status === 'running') startPolling();
 }
 
 // =========================================================================

--- a/runtime-policy.js
+++ b/runtime-policy.js
@@ -6,9 +6,10 @@ const NON_IDEMPOTENT_STEPS = new Set([
   'auth',
   'create_notebook',
   'add_source',
+  'upload_pdf',
   'generate_artifacts',
 ]);
-const STOPPABLE_STEPS = new Set(['wait_source', 'wait_artifacts']);
+const STOPPABLE_STEPS = new Set(['wait_source', 'wait_artifacts', 'wait_pdf_access', 'download_pdf']);
 
 export function isActivePipelineRun(state, runId) {
   return !!runId && state?.status === 'running' && state.runId === runId;
@@ -85,10 +86,11 @@ export function createPipelineStateCoordinator({ readState, writeState }) {
       });
     },
 
-    transition(runId, updates, { expectedSteps = null, ...effects } = {}) {
+    transition(runId, updates, { expectedSteps = null, condition = null, ...effects } = {}) {
       return transact(current => {
         if (!isActivePipelineRun(current, runId)) return null;
         if (expectedSteps && !expectedSteps.includes(current.step)) return null;
+        if (condition && !condition(current)) return null;
         return {
           updates: typeof updates === 'function' ? updates(current) : updates,
           ...effects,
@@ -117,6 +119,10 @@ export function runtimeRecoveryAction(state, hasAlarm) {
 
   if (RECOVERABLE_POLLING_STEPS.has(state.step)) {
     return hasAlarm ? 'none' : 'create_alarm';
+  }
+
+  if (state.step === 'wait_pdf_access' || state.step === 'download_pdf') {
+    return 'wait_pdf_access';
   }
 
   if (NON_IDEMPOTENT_STEPS.has(state.step)) {

--- a/scripts/package-store.ps1
+++ b/scripts/package-store.ps1
@@ -26,6 +26,7 @@ $runtimeFiles = @(
     'popup.html',
     'popup.js',
     'runtime-policy.js',
+    'source-import.js',
     'site-permissions.js'
 )
 

--- a/source-import.js
+++ b/source-import.js
@@ -1,0 +1,67 @@
+// PDF identity comes from detection, never from arbitrary page source type alone.
+export function isPdfImport(url, evidence) {
+  if (!/^https?:\/\//i.test(url || '')) return false;
+  return /\.pdf(?:[?#]|$)/i.test(url) || [
+    'citation_pdf_url', 'pdf_link', 'pdf_content_type', 'arxiv_abstract',
+    'arxiv_pdf', 'arxiv_html', 'arxiv_link', 'publisher_pdf',
+  ].includes(evidence);
+}
+
+export function isConfirmedImportRejection(error) {
+  return error?.code === 'SOURCE_IMPORT_REJECTED';
+}
+
+export function canFallback(state) {
+  return state?.status === 'running' && state.importMethod === 'url' &&
+    !state.fallbackAttempted && isPdfImport(state.originalPdfUrl, state.pdfEvidence);
+}
+
+// Claim each transition before external work. No PDF bytes are persisted in state.
+export function createPdfFallback({ getState, transition, download, upload, poll, fail }) {
+  return async function fallback(runId, { resume = false, file = null } = {}) {
+    const state = await getState();
+    const steps = resume ? ['wait_pdf_access'] : ['add_source', 'wait_source'];
+    const claimed = await transition(runId, {
+      step: 'download_pdf',
+      fallbackAttempted: true,
+      failedUrlSourceId: state.sourceId || null,
+      stepDetail: file ? 'Preparing the selected PDF...' : 'URL import failed. Downloading the PDF for upload...',
+    }, {
+      expectedSteps: steps,
+      condition: current => resume
+        ? current.importMethod === 'url' && current.fallbackAttempted && !current.fallbackUploadStarted
+        : canFallback(current),
+    });
+    if (!claimed) return false;
+    try {
+      const payload = file || await download(state.originalPdfUrl, state.pageUrl);
+      const uploading = await transition(runId, {
+        step: 'upload_pdf', fallbackUploadStarted: true,
+        stepDetail: 'Uploading the replacement PDF. Any failed URL source is retained.',
+      }, { expectedSteps: ['download_pdf'] });
+      if (!uploading) return false;
+      const source = await upload(state.notebookId, payload);
+      if (!source?.id) throw new Error('Upload returned no source ID. Open the notebook before retrying.');
+      const waiting = await transition(runId, {
+        importMethod: 'file', sourceId: source.id, replacementSourceId: source.id,
+        step: 'wait_source', stepStartedAt: new Date().toISOString(),
+        stepDetail: 'Replacement PDF uploaded. Waiting for processing...',
+      }, { expectedSteps: ['upload_pdf'] });
+      if (waiting) await poll();
+      return !!waiting;
+    } catch (error) {
+      if (error?.code === 'PIPELINE_STALE_RUN') return false;
+      const current = await getState();
+      if (current.runId !== runId || current.status !== 'running') return false;
+      if (current.step === 'download_pdf') {
+        await transition(runId, {
+          step: 'wait_pdf_access',
+          stepDetail: `${error.message} Open the popup to grant access or select the PDF.`,
+        }, { expectedSteps: ['download_pdf'] });
+      } else {
+        await fail(runId, `${error.message} The upload was not repeated. Check the existing notebook.`, state.notebookId);
+      }
+      return false;
+    }
+  };
+}

--- a/tests/notebooklm-api.test.js
+++ b/tests/notebooklm-api.test.js
@@ -81,6 +81,38 @@ function reset() {
 
 test.beforeEach(reset);
 
+test('URL import classifies explicit rejection without treating authentication or quota as PDF failures', async () => {
+  for (const status of [400, 401, 403, 422, 429, 500]) {
+    reset();
+    installFetch(url => {
+      if (url.endsWith('/')) return tokenResponse();
+      const method = new URL(url).searchParams.get('rpcids');
+      if (method === __testing.RPCMethod.GET_NOTEBOOK) return rpcResponse(method, [[null, []]]);
+      return mockResponse({ status });
+    });
+    await assert.rejects(addUrlSource('notebook-id-12345', 'https://example.org/paper.pdf'), error =>
+      [400, 422].includes(status) ? error.code === 'SOURCE_IMPORT_REJECTED' : error.code !== 'SOURCE_IMPORT_REJECTED');
+  }
+});
+
+test('malformed URL mutation responses reconcile without repeating the mutation', async () => {
+  let mutations = 0;
+  let reads = 0;
+  installFetch(url => {
+    if (url.endsWith('/')) return tokenResponse();
+    const method = new URL(url).searchParams.get('rpcids');
+    if (method === __testing.RPCMethod.GET_NOTEBOOK) {
+      reads++;
+      return rpcResponse(method, [[null, reads === 1 ? [] : [sourceRow('recovered-source-id', 'https://example.org/paper.pdf')]]]);
+    }
+    mutations++;
+    return mockResponse({ body: 'incomplete response' });
+  });
+  const source = await addUrlSource('notebook-id-12345', 'https://example.org/paper.pdf');
+  assert.equal(source.id, 'recovered-source-id');
+  assert.equal(mutations, 1);
+});
+
 test('request option factories return fresh canonical envelopes', () => {
   const firstTemplate = __testing.requestTemplateOptions();
   const secondTemplate = __testing.requestTemplateOptions();

--- a/tests/source-import.test.js
+++ b/tests/source-import.test.js
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { canFallback, createPdfFallback, isPdfImport, isConfirmedImportRejection } from '../source-import.js';
+import { createPipelineStateCoordinator, runtimeRecoveryAction, canStopPipeline } from '../runtime-policy.js';
+
+function harness(overrides = {}) {
+  let state = { status: 'running', runId: 'run', step: 'wait_source', notebookId: 'notebook',
+    importMethod: 'url', originalPdfUrl: 'https://arxiv.org/pdf/1706.03762', pdfEvidence: 'arxiv_abstract',
+    sourceId: 'failed-source', fallbackAttempted: false };
+  const calls = [];
+  const getState = async () => ({ ...state });
+  const coordinator = createPipelineStateCoordinator({ getState, readState: getState, writeState: async next => { state = next; } });
+  const fallback = createPdfFallback({ getState, transition: async (...args) => (await coordinator.transition(...args)).applied,
+    download: async () => { calls.push('download'); return { filename: 'paper.pdf' }; },
+    upload: async (notebookId) => { calls.push(`upload:${notebookId}`); return { id: 'replacement' }; },
+    poll: async () => calls.push('poll'),
+    fail: async (runId, error) => { state = { ...state, status: 'error', error }; },
+    ...overrides,
+  });
+  return { fallback, getState, calls, set: updates => { state = { ...state, ...updates }; }, coordinator };
+}
+
+test('PDF evidence supports extensionless imports and fails closed for arbitrary pages and legacy state', () => {
+  assert.equal(isPdfImport('https://arxiv.org/pdf/1706.03762', 'arxiv_abstract'), true);
+  assert.equal(isPdfImport('https://publisher.org/file?id=123', 'citation_pdf_url'), true);
+  assert.equal(isPdfImport('https://publisher.org/article', null), false);
+  assert.equal(isPdfImport('javascript:alert(1)', 'citation_pdf_url'), false);
+  assert.equal(canFallback({ status: 'running', originalPdfUrl: 'https://x.org/a.pdf' }), false);
+  for (const code of ['TRANSIENT_MUTATION_UNCERTAIN', 'SOURCE_RECOVERY_AMBIGUOUS', 'AUTH_REQUIRED', 'RATE_LIMITED', undefined]) {
+    assert.equal(isConfirmedImportRejection({ code }), false);
+  }
+  assert.equal(isConfirmedImportRejection({ code: 'SOURCE_IMPORT_REJECTED' }), true);
+});
+
+for (const step of ['add_source', 'wait_source']) {
+  test(`confirmed failure during ${step} uploads once into the same notebook`, async () => {
+    const h = harness(); h.set({ step });
+    await Promise.all([h.fallback('run'), h.fallback('run')]);
+    await h.fallback('run');
+    assert.deepEqual(h.calls, ['download', 'upload:notebook', 'poll']);
+    const state = await h.getState();
+    assert.equal(state.sourceId, 'replacement');
+    assert.equal(state.failedUrlSourceId, 'failed-source');
+    assert.equal(state.importMethod, 'file');
+  });
+}
+
+test('blocked download resumes with a selected file and does not create another notebook', async () => {
+  const h = harness({ download: async () => { throw new Error('SITE_ACCESS_REQUIRED'); } });
+  await h.fallback('run');
+  assert.equal((await h.getState()).step, 'wait_pdf_access');
+  await Promise.all([h.fallback('run', { resume: true, file: { filename: 'paper.pdf' } }),
+    h.fallback('run', { resume: true, file: { filename: 'paper.pdf' } })]);
+  assert.deepEqual(h.calls, ['upload:notebook', 'poll']);
+});
+
+test('cancellation during download prevents upload', async () => {
+  let release;
+  const pending = new Promise(resolve => { release = resolve; });
+  const h = harness({ download: () => pending });
+  const running = h.fallback('run');
+  await new Promise(resolve => setImmediate(resolve));
+  h.set({ status: 'idle', runId: null });
+  release({ filename: 'paper.pdf' });
+  await running;
+  assert.deepEqual(h.calls, []);
+});
+
+test('unknown upload outcome is never replayed', async () => {
+  let uploads = 0;
+  const h = harness({ upload: async () => { uploads++; throw new Error('Network failure'); } });
+  await h.fallback('run');
+  await h.fallback('run', { resume: true });
+  assert.equal(uploads, 1);
+  assert.equal((await h.getState()).status, 'error');
+  assert.equal(runtimeRecoveryAction({ status: 'running', step: 'upload_pdf' }, true), 'interrupt');
+});
+
+test('restart pauses downloads and preserves permission waits without replaying writes', () => {
+  for (const step of ['wait_pdf_access', 'download_pdf']) {
+    assert.equal(runtimeRecoveryAction({ status: 'running', step }, false), 'wait_pdf_access');
+    assert.equal(canStopPipeline({ status: 'running', runId: 'run', step }), true);
+  }
+});


### PR DESCRIPTION
Confirmed URL rejection and later processing failures now share a guarded upload fallback in the existing notebook. Uncertain outcomes reconcile without another mutation, and missing download access can be resumed from the popup. Added the repository maintenance rules.

Validated with 60 tests and the Chrome extension smoke test. CI also checks the release package.

Closes #7.
