### PR TITLE
Prefer HTML paper titles and PDF URL import

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,120 +1,83 @@
-/**
- * Content script: detects PDF URLs on the current page.
- * 
- * Detection strategies:
- * 1. Current page IS a PDF (Content-Type or .pdf extension)
- * 2. Links to PDFs on the page (e.g., arxiv abstract page -> PDF link)
- * 3. Known academic sites with predictable PDF URL patterns
- */
-
-(function () {
-    'use strict';
-
-    // Avoid double-injection
-    if (window.__pdfDetectorInjected) return;
-    window.__pdfDetectorInjected = true;
-
-    function detectSourceTitle() {
-        const candidates = [
-            document.querySelector('meta[name="citation_title"]')?.content,
-            document.querySelector('meta[property="og:title"]')?.content,
-            document.querySelector('h1.title')?.textContent?.replace(/^Title:\s*/i, ''),
-            document.title,
-        ];
-        const title = candidates.find(value => typeof value === 'string' && value.trim());
-        return title ? title.replace(/\s+/g, ' ').trim() : null;
-    }
-
-    /**
-     * Detect if the current page is a PDF or has PDF links.
-     * Returns { isPdf, pdfUrl, pageUrl, source }
-     */
-    function detectPdf() {
-        const currentUrl = window.location.href;
-        const pageUrl = currentUrl;
-        const sourceTitle = detectSourceTitle();
-
-        // Strategy 1: Current URL ends with .pdf
-        if (/\.pdf(\?.*)?$/i.test(currentUrl)) {
-            return { isPdf: true, pdfUrl: currentUrl, pageUrl, source: 'direct_pdf_url', sourceTitle };
-        }
-
-        // Strategy 2: Embedded PDF viewer (Chrome shows PDFs in <embed>)
-        const embed = document.querySelector('embed[type="application/pdf"]');
-        if (embed) {
-            return { isPdf: true, pdfUrl: embed.src || currentUrl, pageUrl, source: 'embedded_pdf', sourceTitle };
-        }
-
-        // Strategy 3: arXiv abstract page -> construct PDF link
-        // https://arxiv.org/abs/2511.12529 -> https://arxiv.org/pdf/2511.12529
-        const arxivAbsMatch = currentUrl.match(/^https?:\/\/arxiv\.org\/abs\/([\d.]+)(v\d+)?/);
-        if (arxivAbsMatch) {
-            const arxivId = arxivAbsMatch[1] + (arxivAbsMatch[2] || '');
-            const pdfUrl = `https://arxiv.org/pdf/${arxivId}`;
-            return { isPdf: true, pdfUrl, pageUrl, source: 'arxiv_abstract', sourceTitle };
-        }
-
-        // Strategy 4: arXiv PDF page
-        const arxivPdfMatch = currentUrl.match(/^https?:\/\/arxiv\.org\/pdf\/([\d.]+)/);
-        if (arxivPdfMatch) {
-            return { isPdf: true, pdfUrl: currentUrl, pageUrl, source: 'arxiv_pdf', sourceTitle };
-        }
-
-        // Strategy 5: Any link on the page that points to a PDF
-        const pdfLinks = [];
-        document.querySelectorAll('a[href]').forEach(a => {
-            const href = a.href;
-            if (/\.pdf(\?.*)?$/i.test(href)) {
-                pdfLinks.push({
-                    url: href,
-                    text: (a.textContent || '').trim().substring(0, 80),
-                });
+// Self-contained so Chrome can inject this function into the active tab.
+export function inspectPaperPage(doc = null, pageUrl = null, publish = false) {
+    doc ||= document;
+    pageUrl ||= location.href;
+    const clean = value => {
+        if (typeof value !== 'string') return null;
+        const title = String(value || '').replace(/\s+/g, ' ').trim()
+            .replace(/^Title:\s*/i, '').replace(/^\[[\d.]+(?:v\d+)?\]\s*/, '')
+            .replace(/\s*\|\s*(?:arXiv(?:\.org)?|PLOS One|eLife|The BMJ|Nature|Frontiers).*$/i, '')
+            .replace(/^Frontiers\s*\|\s*/i, '').trim();
+        if (title.length < 4 || /^(?:https?|file|blob|chrome-extension):/i.test(title) ||
+            /\.pdf(?:[?#].*)?$/i.test(title) || /^[\d.]+(?:v\d+)?$/.test(title) ||
+            /^(?:untitled|download|document|article|paper|full[- ]?text|home)$/i.test(title) ||
+            /^(?:log[ -]?in|sign[ -]?in|access denied|client challenge|just a moment|checking your browser|verify (?:you are|you're) human)(?:\b|$)/i.test(title)) return null;
+        return title.substring(0, 300);
+    };
+    const absolute = value => {
+        if (typeof value !== 'string' || !value.trim()) return null;
+        try { const u = new URL(value, pageUrl); return /^https?:$/.test(u.protocol) ? u.href : null; }
+        catch { return null; }
+    };
+    const meta = Array.from(doc.querySelectorAll('meta')).map(el => ({
+        key: (el.getAttribute('name') || el.getAttribute('property') || '').toLowerCase(),
+        value: el.getAttribute('content') || '',
+    }));
+    const values = key => meta.filter(item => item.key === key).map(item => item.value);
+    const candidates = ['citation_title', 'bepress_citation_title', 'prism.title', 'dc.title', 'dcterms.title']
+        .flatMap(values);
+    for (const script of doc.querySelectorAll('script[type="application/ld+json"]')) {
+        if ((script.textContent || '').length > 200000) continue;
+        try {
+            const queue = [JSON.parse(script.textContent)];
+            let inspected = 0;
+            while (queue.length && inspected++ < 1000) {
+                const node = queue.shift();
+                if (!node || typeof node !== 'object') continue;
+                if (Array.isArray(node)) { queue.push(...node); continue; }
+                const types = [].concat(node['@type'] || []);
+                if (types.some(type => /^(?:ScholarlyArticle|Article|MedicalScholarlyArticle)$/.test(type))) {
+                    candidates.push(node.headline, node.name);
+                }
+                if (node['@graph']) queue.push(node['@graph']);
+                if (node.mainEntity) queue.push(node.mainEntity);
             }
-        });
-
-        // Special case: arXiv HTML page with PDF link
-        const arxivPdfLink = document.querySelector('a[href*="/pdf/"]');
-        if (arxivPdfLink && /arxiv\.org/.test(currentUrl)) {
-            return {
-                isPdf: true,
-                pdfUrl: arxivPdfLink.href,
-                pageUrl,
-                source: 'arxiv_link',
-                sourceTitle,
-            };
-        }
-
-        if (pdfLinks.length > 0) {
-            // Return the first PDF link found
-            return {
-                isPdf: true,
-                pdfUrl: pdfLinks[0].url,
-                pageUrl,
-                source: 'page_link',
-                sourceTitle,
-                allPdfLinks: pdfLinks,
-            };
-        }
-
-        return { isPdf: false, pdfUrl: null, pageUrl, source: null, sourceTitle };
+        } catch { /* Malformed structured data is not a title. */ }
     }
-
-    // Run detection and send result to background
-    const result = detectPdf();
-
-    chrome.runtime.sendMessage({
-        type: 'DETECT_PDF',
-        data: result,
-    }).catch(() => {
-        // Extension context may be invalid, ignore
-    });
-
-    // Also listen for the popup asking for detection
-    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-        if (message.type === 'REQUEST_PDF_DETECTION') {
-            const result = detectPdf();
-            sendResponse(result);
-            return false;
+    candidates.push(...values('og:title'));
+    candidates.push(doc.querySelector('h1.title, h1.article-title, h1')?.textContent, doc.title);
+    const isPdfDocument = /application\/pdf/i.test(doc.contentType || '');
+    const sourceTitle = isPdfDocument ? null : candidates.map(clean).find(Boolean) || null;
+    let pdfUrl = null;
+    let source = null;
+    const arxiv = pageUrl.match(/^https?:\/\/(?:www\.)?arxiv\.org\/(abs|html|pdf)\/([^?#]+?)(?:\.pdf)?(?:[?#].*)?$/i);
+    if (arxiv) {
+        pdfUrl = `https://arxiv.org/pdf/${arxiv[2]}`;
+        source = arxiv[1] === 'abs' ? 'arxiv_abstract' : `arxiv_${arxiv[1]}`;
+    } else if (/\.pdf(?:[?#]|$)/i.test(pageUrl) || isPdfDocument) {
+        pdfUrl = pageUrl;
+        source = isPdfDocument ? 'pdf_content_type' : 'direct_pdf_url';
+    } else {
+        pdfUrl = values('citation_pdf_url').map(absolute).find(Boolean) || null;
+        if (pdfUrl) source = 'citation_pdf_url';
+        if (!pdfUrl) {
+            const links = Array.from(doc.querySelectorAll('a[href], link[type="application/pdf"]')).map(el => {
+                const href = absolute(el.getAttribute('href'));
+                const label = `${el.textContent || ''} ${el.getAttribute('title') || ''} ${el.getAttribute('aria-label') || ''}`.trim();
+                const supplementary = /(?:[-_/](?:figures?|supplement\w*|supporting)[-_.\/]|\b(?:figures? only|supplement\w*|supporting information)\b)/i.test(`${href || ''} ${label}`);
+                const pdf = /\.pdf(?:[?#]|$)|\/pdf(?:[/?#]|$)/i.test(href || '') || /\bpdf\b/i.test(label) || el.getAttribute('type') === 'application/pdf';
+                return { href, label, supplementary, pdf, score: /(?:download|full[ -]?text|article).*pdf|pdf.*(?:download|full[ -]?text|article)/i.test(label) ? 2 : 1 };
+            }).filter(link => link.href && link.pdf && !link.supplementary).sort((a, b) => b.score - a.score);
+            pdfUrl = links[0]?.href || null;
+            if (pdfUrl) source = 'pdf_link';
         }
-    });
-})();
+        if (!pdfUrl) {
+            const embedded = doc.querySelector('embed[type="application/pdf"]');
+            pdfUrl = embedded ? absolute(embedded.getAttribute('src')) : null;
+            if (pdfUrl) source = 'pdf_content_type';
+        }
+    }
+    const result = { isPdf: !!pdfUrl, pdfUrl, pageUrl, source, sourceTitle, pdfEvidence: source };
+    if (publish) chrome.runtime.sendMessage({ type: 'DETECT_PDF', data: result }).catch(() => {});
+    return result;
+}

--- a/pdf-metadata.js
+++ b/pdf-metadata.js
@@ -104,11 +104,11 @@ function titleFromFilename(filename) {
 }
 
 function choosePdfTitle({ payload, pageTitle, filename } = {}) {
-  const metadataTitle = extractPdfMetadataTitle(payload);
-  if (metadataTitle) return { title: metadataTitle, source: 'pdf_metadata' };
-
   const normalizedPageTitle = normalizeTitle(pageTitle);
   if (isUsefulTitle(normalizedPageTitle)) return { title: normalizedPageTitle, source: 'page_metadata' };
+
+  const metadataTitle = extractPdfMetadataTitle(payload);
+  if (metadataTitle) return { title: metadataTitle, source: 'pdf_metadata' };
 
   const filenameTitle = titleFromFilename(filename);
   if (filenameTitle) return { title: filenameTitle, source: 'filename' };

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,6 @@
+import { inspectPaperPage } from './content.js';
 import { choosePdfTitle } from './pdf-metadata.js';
-import { detectionMatchesTab, directDetectionMatchesTab } from './detection-policy.js';
+import { directDetectionMatchesTab } from './detection-policy.js';
 import {
     MAX_PDF_UPLOAD_BYTES,
     assertPdfUploadSize,
@@ -346,77 +347,34 @@ function cleanDetectedTitle(value) {
 }
 
 async function detectSourceTitleFromTab(tab) {
-    if (!tab?.id) return cleanDetectedTitle(tab?.title);
+    if (!tab?.id) return null;
     try {
-        const injected = await chrome.scripting.executeScript({
-            target: { tabId: tab.id },
-            func: () => {
-                const candidates = [
-                    document.querySelector('meta[name="citation_title"]')?.content,
-                    document.querySelector('meta[property="og:title"]')?.content,
-                    document.querySelector('h1.title')?.textContent?.replace(/^Title:\s*/i, ''),
-                    document.title,
-                ];
-                return candidates.find(value => typeof value === 'string' && value.trim()) || null;
-            },
-        });
-        return cleanDetectedTitle(injected?.[0]?.result) || cleanDetectedTitle(tab.title);
-    } catch (_) {
-        return cleanDetectedTitle(tab.title);
-    }
+        const result = await chrome.scripting.executeScript({ target: { tabId: tab.id }, func: inspectPaperPage });
+        return result?.[0]?.result?.sourceTitle || null;
+    } catch { return null; }
 }
 
 async function detectAndRender() {
-    let tab = null;
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id || !tab.url) { renderNoPdf(); return; }
     try {
-        [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-        if (tab?.url) {
-            const url = tab.url;
-            const sourceTitle = await detectSourceTitleFromTab(tab);
-            if (/\.pdf(\?.*)?$/i.test(url)) {
-                const source = /^https?:\/\//i.test(url) ? 'direct_url' : 'local_file';
-                renderDetection({ isPdf: true, pdfUrl: url, pageUrl: url, source, sourceTitle });
-                return;
-            }
-            const arxivAbsMatch = url.match(/^https?:\/\/arxiv\.org\/abs\/([\d.]+)(v\d+)?/);
-            if (arxivAbsMatch) {
-                const pdfUrl = `https://arxiv.org/pdf/${arxivAbsMatch[1]}${arxivAbsMatch[2] || ''}`;
-                renderDetection({ isPdf: true, pdfUrl, pageUrl: url, source: 'arxiv_abstract', sourceTitle });
-                return;
-            }
-            if (/arxiv\.org\/pdf\//.test(url)) {
-                renderDetection({ isPdf: true, pdfUrl: url, pageUrl: url, source: 'arxiv_pdf', sourceTitle });
-                return;
-            }
-            const arxivHtmlMatch = url.match(/^https?:\/\/arxiv\.org\/html\/([\d.]+)(v\d+)?/);
-            if (arxivHtmlMatch) {
-                const pdfUrl = `https://arxiv.org/pdf/${arxivHtmlMatch[1]}${arxivHtmlMatch[2] || ''}`;
-                renderDetection({ isPdf: true, pdfUrl, pageUrl: url, source: 'arxiv_html', sourceTitle });
-                return;
-            }
-        }
-    } catch (_) { /* ignore */ }
-
-    try {
-        const stored = await chrome.storage.local.get('detectedPdf');
-        if (stored.detectedPdf?.isPdf && detectionMatchesTab(stored.detectedPdf, tab)) {
-            renderDetection(stored.detectedPdf);
+        const injected = await chrome.scripting.executeScript({
+            target: { tabId: tab.id }, func: inspectPaperPage, args: [null, null, true],
+        });
+        const result = injected?.[0]?.result;
+        if (result && directDetectionMatchesTab(result, tab)) {
+            if (result.isPdf) renderDetection(result);
+            else renderNoPdf();
             return;
         }
-    } catch (_) { /* ignore */ }
-
-    try {
-        if (tab?.id && tab?.url && !tab.url.startsWith('chrome://')) {
-            await chrome.scripting.executeScript({ target: { tabId: tab.id }, files: ['content.js'] });
-            await new Promise(r => setTimeout(r, 200));
-            const response = await chrome.tabs.sendMessage(tab.id, { type: 'REQUEST_PDF_DETECTION' });
-            if (response?.isPdf && directDetectionMatchesTab(response, tab)) {
-                renderDetection(response);
-                return;
-            }
-        }
-    } catch (_) { /* ignore */ }
-
+    } catch { /* Chrome's PDF viewer can prohibit page injection. */ }
+    const url = tab.url;
+    if (/\.pdf(?:[?#]|$)/i.test(url) || /^https?:\/\/arxiv\.org\/pdf\//i.test(url)) {
+        renderDetection({ isPdf: true, pdfUrl: url, pageUrl: url,
+            source: /arxiv\.org/.test(url) ? 'arxiv_pdf' : 'direct_pdf_url',
+            pdfEvidence: /arxiv\.org/.test(url) ? 'arxiv_pdf' : null, sourceTitle: null });
+        return;
+    }
     renderNoPdf();
 }
 
@@ -427,7 +385,8 @@ async function detectAndRender() {
 function renderDetection(data) {
     const truncated = data.pdfUrl.length > 80 ? data.pdfUrl.substring(0, 77) + '...' : data.pdfUrl;
     const sourceLabel = {
-        direct_pdf_url: 'Direct PDF', embedded_pdf: 'Embedded PDF viewer',
+        direct_pdf_url: 'Direct PDF', pdf_content_type: 'PDF document',
+        citation_pdf_url: 'Publisher PDF metadata', pdf_link: 'Article PDF link', embedded_pdf: 'Embedded PDF viewer',
         arxiv_abstract: 'arXiv abstract page', arxiv_pdf: 'arXiv PDF',
         arxiv_link: 'arXiv PDF link', page_link: 'PDF link on page',
         direct_url: 'Direct PDF URL', local_file: 'Local file',
@@ -457,7 +416,8 @@ function renderDetection(data) {
     </div>
     <button class="btn-generate" id="btn-start">🎧 Generate Artifacts</button>`;
     document.getElementById('btn-start').addEventListener('click', () =>
-        startPipelineFromCurrentTabPdf(data.pageUrl || data.pdfUrl, data.pdfUrl, data.sourceTitle)
+        startPipeline(data.pdfUrl, data.pageUrl, 'pdf', data.sourceTitle, data.pdfEvidence || data.source)
+            .catch(error => alert(error.message))
     );
 }
 
@@ -601,12 +561,12 @@ async function resumeFallbackFromPopup(runId, file = {}) {
 // Pipeline control
 // =========================================================================
 
-async function startPipeline(pdfUrl, pageUrl, sourceType = 'pdf', sourceTitle = null) {
+async function startPipeline(pdfUrl, pageUrl, sourceType = 'pdf', sourceTitle = null, pdfEvidence = null) {
     const btn = document.getElementById('btn-start') || document.getElementById('btn-start-url');
     const originalText = btn?.textContent || '';
     if (btn) { btn.disabled = true; btn.textContent = '⏳ Starting...'; }
     try {
-        const response = await chrome.runtime.sendMessage({ type: 'START_PIPELINE', pdfUrl, pageUrl, sourceType, sourceTitle });
+        const response = await chrome.runtime.sendMessage({ type: 'START_PIPELINE', pdfUrl, pageUrl, sourceType, sourceTitle, pdfEvidence });
         if (!response?.ok) {
             const error = new Error(response?.message || 'Could not start pipeline');
             error.code = response?.code;

--- a/scripts/smoke-extension.mjs
+++ b/scripts/smoke-extension.mjs
@@ -182,15 +182,35 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-const server = createServer((request, response) => {
+const imports = { urls: [], uploads: 0, pdfDownloads: 0, notebookTitles: [] };
+const server = createServer(async (request, response) => {
+  const requestUrl = new URL(request.url, 'http://localhost');
+  if (requestUrl.searchParams.has('rpcids')) {
+    let body = '';
+    for await (const chunk of request) body += chunk;
+    const params = JSON.parse(JSON.parse(new URLSearchParams(body).get('f.req'))[0][0][1]);
+    const method = requestUrl.searchParams.get('rpcids');
+    let result = [[null, []]];
+    if (method === 'CCqFvf') { imports.notebookTitles.push(params[0]); result = [['smoke-notebook-id']]; }
+    if (method === 'izAoDd') { imports.urls.push(params[0][0][2][0]); result = [['smoke-url-source-id']]; }
+    if (method === 'o4cbdc') { imports.uploads++; result = [['smoke-file-source-id']]; }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(`)]}'\n${JSON.stringify([['wrb.fr', method, JSON.stringify(result)]])}`);
+    return;
+  }
+  if (request.url === '/') {
+    response.end('"SNlM0e":"smoke-csrf","FdrFJe":"smoke-session"');
+    return;
+  }
   if (request.url === '/paper.pdf' || request.url === '/paper-two.pdf') {
+    imports.pdfDownloads++;
     response.writeHead(200, { 'content-type': 'application/pdf' });
     response.end('%PDF-1.7\n%%EOF');
     return;
   }
   if (request.url === '/article' || request.url === '/article-next') {
     response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
-    response.end('<!doctype html><title>Article</title><a id="pdf-link" href="/paper.pdf">Download PDF</a>');
+    response.end('<!doctype html><title>Article</title><meta name="citation_title" content="A scholarly HTML title"><a id="pdf-link" href="/paper.pdf">Download PDF</a>');
     return;
   }
   response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
@@ -216,6 +236,11 @@ try {
   const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
   manifest.host_permissions.push(`${origin}/*`);
   await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  // Route the copied test extension to a controlled server. Production files are untouched.
+  const apiPath = join(extensionRoot, 'notebooklm-api.js');
+  await writeFile(apiPath, (await readFile(apiPath, 'utf8'))
+    .replace("const DEFAULT_BASE_URL = 'https://notebook.google.com';", `const DEFAULT_BASE_URL = '${origin}';`)
+    .replace("const LEGACY_BASE_URL = 'https://notebooklm.google.com';", `const LEGACY_BASE_URL = '${origin}';`));
 
   const chromePath = await resolveChrome();
   chrome = spawn(chromePath, [
@@ -277,6 +302,20 @@ try {
   assert(acceptedStop?.ok === true, 'The matching polling run could not be stopped');
   storedState = await evaluate(popup, `chrome.storage.local.get('pipelineState').then(result=>result.pipelineState)`);
   assert(storedState.status === 'idle' && storedState.runId === null, 'Stopped run did not return to idle state');
+
+  await evaluate(popup, `chrome.tabs.update(${tabA.id},{active:true})`);
+  await reload(popup);
+  const downloadsBefore = imports.pdfDownloads;
+  await evaluate(popup, `document.getElementById('btn-start').click()`);
+  for (let attempt = 0; attempt < 50; attempt++) {
+    storedState = await evaluate(popup, `chrome.storage.local.get('pipelineState').then(result=>result.pipelineState)`);
+    if (storedState.step === 'wait_source' || storedState.status === 'error') break;
+    await delay(100);
+  }
+  assert(storedState.step === 'wait_source', `URL import did not reach source polling: ${storedState.error}`);
+  assert(imports.notebookTitles.at(-1) === 'A scholarly HTML title', 'HTML title did not reach notebook creation');
+  assert(imports.urls.at(-1) === `${origin}/paper-two.pdf`, 'Detected PDF URL was not imported');
+  assert(imports.pdfDownloads === downloadsBefore && imports.uploads === 0, 'URL-first import downloaded or uploaded a PDF');
 
   console.log('Chrome extension smoke test passed.');
 } finally {

--- a/tests/paper-page.test.js
+++ b/tests/paper-page.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { inspectPaperPage } from '../content.js';
+
+function element(attrs = {}, textContent = '') {
+  return { textContent, getAttribute: name => attrs[name] ?? null };
+}
+function page({ meta = [], links = [], json = [], title = '', heading = '', contentType = 'text/html' } = {}) {
+  return { title, contentType,
+    querySelectorAll: selector => selector === 'meta' ? meta.map(([name, content]) => element({ name, content }))
+      : selector.startsWith('script') ? json.map(text => element({}, text))
+      : selector.startsWith('a[') ? links.map(([href, label]) => element({ href }, label)) : [],
+    querySelector: selector => selector.startsWith('h1') && heading ? element({}, heading) : null,
+  };
+}
+
+test('scholarly title and extensionless citation PDF take priority over other links', () => {
+  const result = inspectPaperPage(page({ meta: [['citation_title', 'A useful paper title'], ['og:title', 'Social title'],
+    ['citation_pdf_url', '/article/file?id=123&type=printable']], links: [['/supplement.pdf', 'Supplement PDF']] }), 'https://journals.plos.org/article?id=123');
+  assert.equal(result.sourceTitle, 'A useful paper title');
+  assert.equal(result.pdfUrl, 'https://journals.plos.org/article/file?id=123&type=printable');
+  assert.equal(result.pdfEvidence, 'citation_pdf_url');
+});
+
+test('Dublin Core is case insensitive and precedes structured article and social titles', () => {
+  const result = inspectPaperPage(page({ meta: [['DC.Title', 'Dublin Core paper title'], ['og:title', 'Social title']],
+    json: [JSON.stringify({ '@type': 'ScholarlyArticle', headline: 'Structured title' })] }), 'https://example.org/article');
+  assert.equal(result.sourceTitle, 'Dublin Core paper title');
+});
+
+test('article JSON-LD precedes Open Graph and headings, while malformed data is ignored', () => {
+  const result = inspectPaperPage(page({ meta: [['og:title', 'Social title']], heading: 'Heading',
+    json: ['bad JSON', JSON.stringify({ '@graph': [{ '@type': 'WebSite', name: 'Not the article' },
+      { '@type': ['Article'], headline: 'The structured paper title' }] })] }), 'https://example.org/article');
+  assert.equal(result.sourceTitle, 'The structured paper title');
+});
+
+test('eLife selects the full paper and preserves its selected version', () => {
+  const result = inspectPaperPage(page({ meta: [['dc.title', 'Continuous endosomes form functional subdomains']],
+    links: [['https://elifesciences.org/download/token/elife-91194-figures-v1.pdf?_hash=a', 'Download figures PDF'],
+      ['https://elifesciences.org/download/token/elife-91194-v1.pdf?_hash=b', 'Download PDF']] }), 'https://elifesciences.org/articles/91194');
+  assert.equal(result.pdfUrl, 'https://elifesciences.org/download/token/elife-91194-v1.pdf?_hash=b');
+  assert.equal(result.sourceTitle, 'Continuous endosomes form functional subdomains');
+});
+
+test('arXiv PDF URL preserves explicit versions, including legacy identifiers', () => {
+  for (const id of ['1706.03762v2', 'hep-th/9901001v1']) {
+    const result = inspectPaperPage(page(), `https://arxiv.org/abs/${id}`);
+    assert.equal(result.pdfUrl, `https://arxiv.org/pdf/${id}`);
+    assert.equal(result.pdfEvidence, 'arxiv_abstract');
+  }
+});
+
+test('missing titles, browser challenges, filenames and empty PDF metadata do not become article metadata', () => {
+  for (const title of ['', 'Client Challenge', 'Checking your browser - reCAPTCHA', 'Sign in - Google', '1706.03762.pdf', 'https://example.org/a']) {
+    const result = inspectPaperPage(page({ title, meta: [['citation_pdf_url', '']] }), 'https://example.org/article');
+    assert.equal(result.sourceTitle, null, title);
+    assert.equal(result.pdfUrl, null);
+  }
+});
+
+test('BMJ metadata and Frontiers download endpoints work without a PDF extension', () => {
+  assert.equal(inspectPaperPage(page({ meta: [['citation_pdf_url', '/content/article.full.pdf']] }),
+    'https://www.bmj.com/content/article').pdfUrl, 'https://www.bmj.com/content/article.full.pdf');
+  assert.equal(inspectPaperPage(page({ links: [['/journals/ai/articles/10.3389/test/pdf', 'Download PDF']] }),
+    'https://www.frontiersin.org/journals/ai/articles/10.3389/test/full').pdfEvidence, 'pdf_link');
+});

--- a/tests/pdf-metadata.test.js
+++ b/tests/pdf-metadata.test.js
@@ -46,3 +46,8 @@ test('allows NotebookLM to name the notebook when no trustworthy title exists', 
     filename: 's42256-026-01283-z.pdf',
   }), { title: null, source: 'notebooklm' });
 });
+
+test('a useful HTML title avoids inspecting PDF bytes', () => {
+  assert.deepEqual(choosePdfTitle({ pageTitle: 'The actual article title', payload: 'not valid base64' }),
+    { title: 'The actual article title', source: 'page_metadata' });
+});


### PR DESCRIPTION
Article pages now provide the notebook title and full-paper PDF link before URL import. Missing titles are left to Gemini Notebook, and PDF downloads are reserved for upload fallback or local files. Includes versioned arXiv links and eLife full-paper selection.

Validated with 68 tests and Chrome smoke coverage confirming that URL import uses the HTML title without downloading or uploading the PDF.

Closes #6.
