### PR TITLE
Raise PDF upload limit to 40 MiB and prepare v1.3.0

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy for ScholarRelay
 
-Last updated: August 30, 2026
+Last updated: September 3, 2026
 
 ScholarRelay is an independent browser extension that helps a user add a PDF or webpage to the user's own Gemini Notebook account (formerly NotebookLM) and request artifacts. It is not affiliated with, authorized by, or endorsed by Google.
 
@@ -18,6 +18,8 @@ The extension handles only data needed for a user-requested workflow:
 The extension never asks for, reads, stores, or transmits a Google password or multi-factor authentication code. It does not use the Chrome Cookies API. Temporary Gemini Notebook CSRF and session values are kept only in service-worker memory and are discarded when that worker stops.
 
 ## How data is used and shared
+
+HTML metadata is read before remote PDF import. PDF bytes are downloaded only when upload is needed, such as after a confirmed URL import failure.
 
 Data is used only to detect the source selected by the user, upload or import it into the user's Gemini Notebook account, apply the user's notebook settings, request the selected artifacts, and report progress.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ScholarRelay는 PDF, 연구 논문 또는 웹페이지를 Gemini Notebook(이전
 ### 주요 기능
 
 - 현재 탭에서 PDF, arXiv 논문, 웹페이지를 감지해 Gemini Notebook 소스로 추가합니다.
-- 원격 PDF와 로컬 PDF 업로드를 지원하며, PDF 메타데이터에서 신뢰할 수 있는 논문 제목을 찾습니다.
+- HTML 메타데이터에서 논문 제목과 PDF 링크를 먼저 찾고 URL로 가져옵니다. 가져오기가 실패한 경우에만 PDF를 내려받아 업로드하며, 로컬 PDF도 지원합니다.
 - 새 노트북을 선택한 기존 컬렉션에 자동으로 추가할 수 있습니다.
 - 감지한 논문 제목을 우선 사용하거나 Gemini Notebook의 자동 제목 생성을 선택할 수 있습니다.
 - 오디오, 비디오, 보고서, 퀴즈, 플래시카드, 인포그래픽, 슬라이드, 마인드맵, 데이터 표를 원하는 조합으로 생성합니다.
@@ -71,12 +71,12 @@ Chrome 120 이상과 Gemini Notebook에 로그인할 Google 계정이 필요합�
 
 ### 권한 및 문제 해결
 
-- 현재 페이지와 다른 사이트에 있는 PDF를 직접 내려받아야 할 때만 해당 PDF 사이트에 대한 Chrome 권한을 요청합니다. 거부하면 Gemini Notebook URL 가져오기를 시도하며, 필요하면 파일을 직접 업로드할 수 있습니다.
+- 현재 페이지와 다른 사이트에 있는 PDF를 직접 내려받아야 할 때만 해당 PDF 사이트에 대한 Chrome 권한을 요청합니다. URL 가져오기는 다운로드 권한 없이 먼저 시도하며, 업로드가 필요할 때만 권한을 요청합니다. 권한을 거부하면 파일을 직접 선택할 수 있습니다.
 - 로컬 `file://` PDF를 읽으려면 확장 프로그램 세부정보에서 **파일 URL에 대한 액세스 허용**을 켜야 할 수 있습니다.
 - 실행되지 않으면 [Gemini Notebook](https://notebook.google.com)에 로그인되어 있는지 확인하고 다시 시도합니다.
 - 컬렉션이 보이지 않으면 Gemini Notebook에서 컬렉션을 만든 뒤 설정의 새로고침 버튼을 클릭합니다.
-- URL 소스를 추가하지 못하면 **Upload Local PDF**로 파일을 직접 업로드합니다.
-- Chrome 메모리를 안전하게 유지하기 위해 직접 내려받기 및 로컬 업로드는 32 MiB로 제한됩니다. 더 큰 원격 PDF는 URL 가져오기를 사용하고, 더 큰 로컬 파일은 Gemini Notebook에서 직접 업로드합니다.
+- PDF URL 가져오기나 처리 실패가 확인되면 같은 노트북에 PDF 업로드를 한 번 시도합니다. 다운로드 권한이 필요하면 팝업에서 허용하거나 PDF를 직접 선택하세요. 시간 초과나 결과가 불확실한 응답에서는 추가 업로드를 실행하지 않습니다.
+- Chrome 메모리를 안전하게 유지하기 위해 직접 내려받기 및 로컬 업로드는 40 MiB로 제한됩니다. 더 큰 원격 PDF는 URL 가져오기를 사용하고, 더 큰 로컬 파일은 Gemini Notebook에서 직접 업로드합니다.
 
 ---
 
@@ -85,7 +85,7 @@ Chrome 120 이상과 Gemini Notebook에 로그인할 Google 계정이 필요합�
 ### Highlights
 
 - Detects PDFs, arXiv papers, and webpages in the current tab and adds them to Gemini Notebook.
-- Supports remote and local PDF uploads and extracts trustworthy paper titles from PDF metadata.
+- Reads paper titles and PDF links from HTML first, then imports the PDF URL. Downloads and uploads only after a confirmed import failure, with local PDF uploads also supported.
 - Can automatically add each new notebook to a selected existing collection.
 - Can prefer the detected paper title or let Gemini Notebook choose the notebook title.
 - Generates any combination of audio, video, reports, quizzes, flashcards, infographics, slide decks, mind maps, and data tables.
@@ -135,12 +135,12 @@ Source processing and artifact generation continue if collection assignment fail
 
 ### Permissions and troubleshooting
 
-- Chrome asks for access to a specific PDF website only when the PDF is hosted on a different site and must be downloaded directly. If you decline, ScholarRelay tries Gemini Notebook URL import and keeps manual upload available.
+- Chrome asks for access to a specific PDF website only when the PDF is hosted on a different site and must be downloaded directly. URL import is tried first without download access. If upload fallback needs permission, you can grant it or select the PDF manually.
 - To read local `file://` PDFs, enable **Allow access to file URLs** in the extension's details.
 - If a run does not start, confirm that you are signed in at [Gemini Notebook](https://notebook.google.com) and retry.
 - If a collection is missing, create it in Gemini Notebook and use the refresh button in Settings.
-- If a URL source cannot be added, use **Upload Local PDF** to upload the file directly.
-- Direct downloads and local uploads are limited to 32 MiB to keep Chrome memory use safe. Larger remote PDFs use URL import, while larger local files should be uploaded directly in Gemini Notebook.
+- Confirmed PDF URL import or processing failures trigger one upload fallback in the same notebook. If download access is needed, reopen the popup to grant it or select the PDF manually. Timeouts and uncertain responses do not trigger another upload.
+- Direct downloads and local uploads are limited to 40 MiB to keep Chrome memory use safe. Larger remote PDFs use URL import, while larger local files should be uploaded directly in Gemini Notebook.
 
 ## Credits and compatibility
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # ScholarRelay development notes
 
-Recorded on September 3, 2026. This is a retrospective of the engineering problems, decisions, tradeoffs, and Chrome Web Store submission history through v1.2.2. It also explains which development files are worth keeping.
+Recorded on September 3, 2026. This history covers engineering decisions, validation, and Chrome Web Store submissions. Earlier sections describe v1.2.2. The v1.3.0 entry records the subsequent changes. Maintenance rules are in [AGENTS.md](../AGENTS.md).
 
 The account below was reconstructed from commits, pull requests, release assets, recorded development and submission sessions, a targeted search of the maintainer's two mailboxes, and a signed-in developer-console check on September 3. Code links and release links provide publicly inspectable evidence. Session observations are identified where they add information that Git cannot establish. Email bodies, private account links, authentication values, and customer data are not included.
 
@@ -207,3 +207,21 @@ The old local `scholar-relay-v1.2.1.zip` and its checksum sidecar were removed a
 The screenshot capture utility still uses the earlier port-and-flag loading approach and a Windows-specific cleanup guard. It has not received the smoke harness's later DevTools pipe and portable-cleanup changes. Keep its source and existing artwork, but check compatibility before the next asset regeneration. This documentation and cleanup task did not run it or change its behavior.
 
 The project is small enough that removing reusable artwork or release tools would save little space while making future updates harder. Retiring verified duplicate builds is the useful cleanup here.
+
+## v1.3.0 URL import, recovery, and popup update
+
+The previous remote PDF path downloaded and uploaded bytes to obtain metadata even when the article HTML already supplied a useful title. Issues #6 and #7 separate title detection from transfer and add one safe upload fallback. PR #9 merged recovery first, PR #10 then enabled URL-first import. The user subsequently included issue #5, completed in PR #11. Issue #8 raises the upload limit and prepares this release.
+
+Title candidates follow scholarly metadata, article JSON-LD, Open Graph, article heading, and document title. Detection preserves arXiv versions and recognizes publisher metadata and full-paper download links, including eLife. Generic titles, filenames, URLs, challenge pages, figures, and supplements are excluded. A missing HTML title leaves naming to Gemini Notebook. A useful HTML title bypasses PDF metadata decoding.
+
+Confirmed import rejection or a reported source-processing error can claim one upload fallback in the existing notebook. The failed URL source is retained and recorded. Artifact generation uses the replacement source. Authentication, quota errors, ambiguous mutation responses, pending processing, and the ten-minute timeout do not initiate another upload. Downloads that need access pause for a popup permission action or manual file selection. Interrupted uploads with unknown outcomes are never replayed automatically. Older saved states are handled conservatively.
+
+The 40 MiB limit is 41,943,040 bytes. A real Chrome extension smoke transferred that payload through runtime messaging and the resumable upload client to a controlled local server. The server received exactly the expected bytes and SHA-256. The full JSON message was 55,924,172 bytes, below 64 MiB. A 40 MiB plus one byte message was rejected, as was an oversized streaming response without Content-Length.
+
+On the local Windows run, the transfer and oversized-message check took about four seconds. The popup timer observed a 1.02 second maximum gap. Samples reached approximately 109 MiB of popup JavaScript heap, 107 MiB of worker heap, and 133 MiB of worker backing storage. These are sampled categories, not a measurement of total peak browser memory. Large Base64 messages still cause a brief pause and substantial temporary allocations. The cap is an engineering bound, not a guarantee for every device or a Google quota.
+
+Validation includes 69 deterministic tests, real Chrome extension smoke, syntax and package gates, metadata precedence and publisher fixtures, immediate and delayed confirmed failure, permission resumption, overlapping fallback calls, cancellation, restart, ambiguous responses, and rejection above the size bound. Controlled transport uses synthetic PDF bytes and does not claim Google ingestion of a 40 MiB document.
+
+Separately, the signed-in Gemini Notebook UI accepted the arXiv PDF at https://arxiv.org/pdf/1706.03762, the eLife PDF at https://elifesciences.org/articles/91194.pdf, and a small valid local PDF. The eLife source view exposed the full paper, including the Introduction. These live checks establish service acceptance. The isolated Chrome smoke exercises the extension itself against controlled responses.
+
+The completed popup measured 344 pixels high at 360 pixels wide. Results and the notebook link remain visible, completed workflow details are collapsed, and settings use a bounded scroll area. README and store screenshots were regenerated and visually inspected. Korean and English release notes are in [v1.3.0](releases/v1.3.0.md).

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,21 @@
+# ScholarRelay v1.3.0
+
+## 한국어
+
+- HTML 메타데이터에서 논문 제목을 찾고 PDF URL을 먼저 가져옵니다. 신뢰할 수 있는 제목이 없으면 Gemini Notebook이 이름을 정합니다.
+- PDF URL 가져오기가 명확하게 실패하면 같은 노트북에 PDF를 한 번 업로드합니다. 필요한 사이트 권한을 허용하거나 파일을 직접 선택해 이어갈 수 있습니다.
+- 직접 내려받기와 로컬 PDF 업로드 한도를 40 MiB로 늘렸습니다. 더 큰 원격 PDF는 URL로 가져오고, 더 큰 로컬 파일은 Gemini Notebook에서 직접 업로드하세요.
+- 팝업의 여백을 줄이고 완료 결과와 노트북 링크를 바로 볼 수 있게 했습니다.
+
+## English
+
+- Read paper titles from HTML metadata and import the PDF URL first. Gemini Notebook chooses the name when no trustworthy title is available.
+- After a confirmed PDF URL import failure, upload the PDF once into the same notebook. Grant the required site permission or choose the file to resume.
+- Raise direct download and local PDF upload limits to 40 MiB. Import larger remote PDFs by URL and upload larger local files directly in Gemini Notebook.
+- Reduce popup spacing and keep completed results and the notebook link immediately visible.
+
+40 MiB = 40 × 1024 × 1024 bytes. Issues #5, #6, #7, and #8.
+
+Install the canonical ZIP below for manual installation. Its SHA-256 checksum is provided in the matching `.sha256` asset. GitHub source archives are not the store package.
+
+수동 설치에는 아래 ZIP을 사용하세요. SHA-256 체크섬은 같은 이름의 `.sha256` 파일에 있습니다. GitHub 소스 압축 파일은 스토어 제출 패키지와 다릅니다.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "minimum_chrome_version": "120",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scholar-relay",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pdf-file-policy.js
+++ b/pdf-file-policy.js
@@ -1,4 +1,4 @@
-export const MAX_PDF_UPLOAD_BYTES = 32 * 1024 * 1024;
+export const MAX_PDF_UPLOAD_BYTES = 40 * 1024 * 1024;
 
 export function decodedBase64ByteLength(value) {
   if (typeof value !== 'string') return 0;
@@ -14,7 +14,7 @@ export function pdfSizeError(size, limit = MAX_PDF_UPLOAD_BYTES) {
   const actualMiB = Number.isFinite(size) ? (size / (1024 * 1024)).toFixed(1) : 'unknown';
   const error = new Error(
     `This PDF is ${actualMiB} MiB. ScholarRelay local uploads are limited to ${limitMiB} MiB ` +
-    'to keep Chrome memory use safe. Use the PDF URL directly or choose a smaller file.'
+    'to bound Chrome memory use. Import the remote PDF URL or upload larger local files directly in Gemini Notebook.'
   );
   error.code = 'PDF_TOO_LARGE';
   return error;

--- a/popup.js
+++ b/popup.js
@@ -818,7 +818,7 @@ async function startPipelineFromCurrentTabPdf(pageUrl, pdfUrl = null, detectedSo
                 await startPipeline(pdfUrl, pageUrl || tab.url || pdfUrl, 'pdf', pageTitle);
                 return;
             }
-            const error = new Error(payload.error || 'This local PDF exceeds the 32 MiB safe upload limit.');
+            const error = new Error(payload.error || 'This local PDF exceeds the 40 MiB safe upload limit.');
             error.code = payload.code;
             throw error;
         }

--- a/scripts/smoke-extension.mjs
+++ b/scripts/smoke-extension.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
 
 const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const tempRoot = await mkdtemp(join(tmpdir(), 'scholar-relay-smoke-'));
@@ -182,9 +183,21 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-const imports = { urls: [], uploads: 0, pdfDownloads: 0, notebookTitles: [] };
+const imports = { urls: [], uploads: 0, pdfDownloads: 0, notebookTitles: [], uploadedBytes: 0, uploadedHash: null };
 const server = createServer(async (request, response) => {
   const requestUrl = new URL(request.url, 'http://localhost');
+  if (requestUrl.pathname === '/upload/_/') {
+    response.writeHead(200, { 'x-goog-upload-url': `${origin}/upload-bytes` });
+    response.end();
+    return;
+  }
+  if (requestUrl.pathname === '/upload-bytes') {
+    const hash = createHash('sha256');
+    for await (const chunk of request) { imports.uploadedBytes += chunk.length; hash.update(chunk); }
+    imports.uploadedHash = hash.digest('hex');
+    response.end('ok');
+    return;
+  }
   if (requestUrl.searchParams.has('rpcids')) {
     let body = '';
     for await (const chunk of request) body += chunk;
@@ -331,6 +344,54 @@ try {
   assert(layout.height <= 600 && layout.width <= 360, 'Completed popup overflows its viewport');
   assert(layout.resultBottom < 600 && layout.linkBottom < 600 && layout.collapsed, 'Results are not immediately visible');
   console.log(`Completed popup layout: ${JSON.stringify(layout)}`);
+
+  // Exercise the real Chrome message bridge and the complete file upload client.
+  await evaluate(popup, `chrome.storage.local.set({pipelineState:{status:'idle'}})`);
+  const size = 40 * 1024 * 1024;
+  const expectedBytes = Buffer.alloc(size, 32);
+  expectedBytes.write('%PDF-1.7\n');
+  const expectedHash = createHash('sha256').update(expectedBytes).digest('hex');
+  const started = Date.now();
+  const baselineHeap = await popup.call('Runtime.getHeapUsage');
+  const transfer = await evaluate(popup, `(async()=>{
+    const bytes=new Uint8Array(${size}).fill(32); bytes.set(new TextEncoder().encode('%PDF-1.7\\n'));
+    const fileDataBase64=await new Promise(resolve=>{const reader=new FileReader();reader.onload=()=>resolve(reader.result.split(',')[1]);reader.readAsDataURL(new Blob([bytes],{type:'application/pdf'}));});
+    let last=performance.now(),maxGapMs=0,ticks=0;
+    const timer=setInterval(()=>{const now=performance.now();maxGapMs=Math.max(maxGapMs,now-last);last=now;ticks++;},25);
+    const message={type:'START_PIPELINE_FILE',fileName:'large-smoke.pdf',fileDataBase64,sourceTitle:'Large PDF validation'};
+    const messageBytes=new TextEncoder().encode(JSON.stringify(message)).byteLength;
+    const response=await chrome.runtime.sendMessage(message);
+    clearInterval(timer);
+    return {response,messageBytes,maxGapMs,ticks};
+  })()`);
+  assert(transfer.response.ok, `Large PDF start failed: ${JSON.stringify(transfer.response)}`);
+  assert(transfer.messageBytes < 64 * 1024 * 1024, 'Large PDF message exceeds Chrome limit');
+  const targets = await browserConnection.call('Target.getTargets');
+  const workerTarget = targets.targetInfos.find(target => target.type === 'service_worker' && target.url.includes(extensionId));
+  const workerAttachment = workerTarget ? await browserConnection.call('Target.attachToTarget', { targetId: workerTarget.targetId, flatten: true }) : null;
+  const peak = { popupHeap: baselineHeap.usedSize, workerHeap: 0, workerBacking: 0 };
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const heap = await popup.call('Runtime.getHeapUsage');
+    peak.popupHeap = Math.max(peak.popupHeap, heap.usedSize);
+    if (workerAttachment) {
+      const workerHeap = await browserConnection.call('Runtime.getHeapUsage', {}, workerAttachment.sessionId);
+      peak.workerHeap = Math.max(peak.workerHeap, workerHeap.usedSize);
+      peak.workerBacking = Math.max(peak.workerBacking, workerHeap.backingStorageSize || 0);
+    }
+    storedState = await evaluate(popup, `chrome.storage.local.get('pipelineState').then(result=>result.pipelineState)`);
+    if (storedState.step === 'wait_source' || storedState.status === 'error') break;
+    await delay(50);
+  }
+  assert(storedState.step === 'wait_source', `Large upload failed: ${storedState.error || storedState.step}`);
+  assert(imports.uploadedBytes === size && imports.uploadedHash === expectedHash, 'Large uploaded bytes differ from the selected PDF');
+  await evaluate(popup, `chrome.runtime.sendMessage({type:'ABORT_PIPELINE',runId:${JSON.stringify(storedState.runId)}})`);
+  const rejected = await evaluate(popup, `(async()=>{
+    const bytes=new Uint8Array(${size + 1}).fill(32);bytes.set(new TextEncoder().encode('%PDF-1.7\\n'));
+    const b64=await new Promise(resolve=>{const r=new FileReader();r.onload=()=>resolve(r.result.split(',')[1]);r.readAsDataURL(new Blob([bytes]));});
+    return chrome.runtime.sendMessage({type:'START_PIPELINE_FILE',fileName:'too-large.pdf',fileDataBase64:b64});
+  })()`);
+  assert(!rejected.ok && rejected.code === 'PDF_TOO_LARGE', '40 MiB plus one byte was not rejected');
+  console.log(`40 MiB transfer: ${JSON.stringify({messageBytes:transfer.messageBytes,elapsedMs:Date.now()-started,maxTimerGapMs:transfer.maxGapMs,peak,sha256:imports.uploadedHash})}`);
 
   console.log('Chrome extension smoke test passed.');
 } finally {

--- a/tests/safety-policy.test.js
+++ b/tests/safety-policy.test.js
@@ -39,7 +39,7 @@ test('PDF size and base64 guards enforce a bounded local bridge', () => {
   assert.equal(assertPdfUploadSize(MAX_PDF_UPLOAD_BYTES), MAX_PDF_UPLOAD_BYTES);
   assert.throws(
     () => assertPdfUploadSize(MAX_PDF_UPLOAD_BYTES + 1),
-    error => error?.code === 'PDF_TOO_LARGE' && /32 MiB/.test(error.message)
+    error => error?.code === 'PDF_TOO_LARGE' && /40 MiB/.test(error.message)
   );
   assert.equal(decodedBase64ByteLength('TQ=='), 1);
   assert.equal(decodedBase64ByteLength('TWE='), 2);
@@ -76,6 +76,19 @@ test('streaming PDF reads stop before an unbounded response is allocated', async
     () => readResponseWithinLimit(oversized, 5),
     error => error?.code === 'PDF_TOO_LARGE'
   );
+});
+
+test('40 MiB streaming boundary is enforced without a Content-Length header', async () => {
+  const chunk = new Uint8Array(1024 * 1024);
+  let reads = 0;
+  const response = new Response(new ReadableStream({
+    pull(controller) {
+      if (reads++ < 40) controller.enqueue(chunk);
+      else { controller.enqueue(new Uint8Array(1)); controller.close(); }
+    },
+  }));
+  await assert.rejects(readResponseWithinLimit(response), error => error.code === 'PDF_TOO_LARGE');
+  assert.equal(reads, 41);
 });
 
 test('serialized pipeline claims allow exactly one active run', async () => {

--- a/tests/store-readiness.test.js
+++ b/tests/store-readiness.test.js
@@ -23,7 +23,7 @@ test('store manifest uses minimum permissions and a production-safe alarm baseli
   assert.equal(manifest.name, '__MSG_extensionName__');
   assert.equal(manifest.description, '__MSG_extensionDescription__');
   assert.equal(manifest.default_locale, 'en');
-  assert.equal(manifest.version, '1.2.2');
+  assert.equal(manifest.version, '1.3.0');
   assert.equal(manifest.minimum_chrome_version, '120');
   assert.equal(manifest.permissions.includes('cookies'), false);
   assert.equal(manifest.host_permissions.includes('*://*/*'), false);


### PR DESCRIPTION
Raise the PDF upload limit to 40 MiB and prepare v1.3.0 with bilingual notes and current documentation. Larger local files receive direct Gemini Notebook upload guidance.

Validated 69 tests, syntax, packaging, and Chrome smoke. An actual 40 MiB message and upload preserved every byte. Both messaging and streaming reject 40 MiB plus one byte. Full JSON is 53.33 MiB. Sampled memory and the brief UI pause are recorded in the development history. Live service checks accepted arXiv, eLife, and a local PDF.

Closes #8. Includes the release preparation for #5, #6, and #7.
