### PR TITLE
Fix popup rendering, polling edges and PDF metadata memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ ScholarRelay(Scholar Relay)는 PDF, arXiv 연구 논문, 웹페이지를 Gemini 
 - HTML 메타데이터에서 논문 제목과 PDF 링크를 먼저 찾고 URL로 가져옵니다. 가져오기가 실패한 경우에만 PDF를 내려받아 업로드하며, 로컬 PDF도 지원합니다.
 - 새 노트북을 선택한 기존 컬렉션에 자동으로 추가할 수 있습니다.
 - 감지한 논문 제목을 우선 사용하거나 Gemini Notebook의 자동 제목 생성을 선택할 수 있습니다.
+- 로컬 PDF 제목은 제한된 앞뒤 영역에서 확인하며, 찾지 못하면 파일명 또는 Gemini Notebook의 자동 제목을 사용합니다.
 - 오디오, 비디오, 보고서, 퀴즈, 플래시카드, 인포그래픽, 슬라이드, 마인드맵, 데이터 표를 원하는 조합으로 생성합니다.
 - 팝업을 닫아도 Chrome의 절전형 알람으로 진행 상태를 확인하며 완료 알림, 차임, 노트북 자동 열기를 설정할 수 있습니다.
 
@@ -90,6 +91,7 @@ Chrome 120 이상과 Gemini Notebook에 로그인할 Google 계정이 필요합�
 - Reads paper titles and PDF links from HTML first, then imports the PDF URL. Downloads and uploads only after a confirmed import failure, with local PDF uploads also supported.
 - Can automatically add each new notebook to a selected existing collection.
 - Can prefer the detected paper title or let Gemini Notebook choose the notebook title.
+- Checks bounded head and tail regions for local PDF titles, then falls back to a useful filename or Gemini Notebook naming.
 - Generates any combination of audio, video, reports, quizzes, flashcards, infographics, slide decks, mind maps, and data tables.
 - Uses Chrome's event-driven alarms to monitor progress after the popup closes, with optional notifications, a completion chime, and automatic notebook opening.
 

--- a/background.js
+++ b/background.js
@@ -319,7 +319,7 @@ async function downloadRemotePdfForUpload(pdfUrl, pageUrl = null) {
 
     return {
         filename,
-        mimeType: /application\/pdf/i.test(contentType) ? 'application/pdf' : 'application/pdf',
+        mimeType: 'application/pdf',
         fileData,
     };
 }
@@ -558,12 +558,14 @@ async function completePipeline(runId) {
     const failedCount = tasks.filter(t => t.status === 'failed').length;
     const allSucceeded = totalCount > 0 && failedCount === 0 && completedCount === totalCount;
 
-    if (completedCount === 0) {
+    if (totalCount > 0 && completedCount === 0) {
         await failPipeline(runId, 'All artifact generations failed. No artifacts were generated.');
         return;
     }
 
-    const stepDetail = allSucceeded
+    const stepDetail = totalCount === 0
+        ? 'Source imported successfully. No artifacts were requested.'
+        : allSucceeded
         ? 'All artifacts generated successfully!'
         : `Partial success: ${completedCount}/${totalCount} artifacts generated (${failedCount} failed).`;
 
@@ -590,7 +592,9 @@ async function completePipeline(runId) {
     const artifactLabel = allSucceeded
         ? (completedCount === 1 ? '1 artifact' : `${completedCount} artifacts`)
         : `${completedCount}/${totalCount} artifacts`;
-    const notificationMessage = allSucceeded
+    const notificationMessage = totalCount === 0
+        ? `Notebook ${nbTitle}is ready. Source imported without artifacts. Click to open.`
+        : allSucceeded
         ? `Notebook ${nbTitle}is ready with ${artifactLabel}. Click to open.`
         : `Notebook ${nbTitle}is partially ready with ${artifactLabel} (${failedCount} failed). Click to open.`;
 
@@ -751,6 +755,7 @@ async function tickSourcePoll(state) {
     try {
         const settings = await getSettings();
         await requireActiveRun(runId, ['generate_artifacts']);
+        assertArtifactSelection(settings);
 
         if (settings.collectionId) {
             await transitionRun(runId, {
@@ -937,6 +942,11 @@ async function tickSourcePoll(state) {
 async function tickArtifactPoll(state) {
     const runId = state.runId;
     await requireActiveRun(runId, ['wait_artifacts']);
+    const tasks = state.tasks || [];
+    if (tasks.length === 0) {
+        await completePipeline(runId);
+        return;
+    }
     const ARTIFACT_TIMEOUT_MS = 1200000; // 20 minutes
     const elapsed = pollingElapsedMs(state.stepStartedAt);
 
@@ -945,7 +955,6 @@ async function tickArtifactPoll(state) {
         return;
     }
 
-    const tasks = state.tasks || [];
     const updatedTasks = [...tasks];
     let statusByTaskId = new Map();
 
@@ -996,37 +1005,50 @@ async function tickArtifactPoll(state) {
 
 const runExclusivePollTick = createExclusiveRunner();
 
-chrome.alarms.onAlarm.addListener(async (alarm) => {
+async function handlePollAlarm(alarm) {
     if (alarm.name !== ALARM_NAME) return;
-    await bootReconciliationPromise;
-    const ran = await runExclusivePollTick(async () => {
-        const state = await getState();
+    let step = 'unknown';
+    try {
+        await bootReconciliationPromise;
+        const ran = await runExclusivePollTick(async () => {
+            const state = await getState();
+            step = state?.step || 'idle';
 
-        if (!state || state.status !== 'running') {
-            await pipelineState.effectWhen(
-                current => current?.status !== 'running',
-                () => chrome.alarms.clear(ALARM_NAME)
-            );
-            return;
+            if (!state || state.status !== 'running') {
+                const cleanup = await pipelineState.effectWhen(
+                    current => current?.status !== 'running',
+                    () => chrome.alarms.clear(ALARM_NAME)
+                );
+                if (cleanup.effectError) throw cleanup.effectError;
+                return;
+            }
+
+            console.log(`[Alarm] tick -- step=${state.step}`);
+
+            if (state.step === 'wait_source') {
+                await tickSourcePoll(state);
+            } else if (state.step === 'wait_artifacts') {
+                await tickArtifactPoll(state);
+            } else if (state.step === 'generate_artifacts') {
+                console.log('[Alarm] Artifact start phase still in progress');
+            } else {
+                console.log(`[Alarm] tick during non-polling step '${state.step}', ignoring`);
+            }
+        });
+
+        if (!ran) {
+            console.warn('[Alarm] Previous poll tick is still running; skipping overlap');
         }
-
-        console.log(`[Alarm] tick -- step=${state.step}`);
-
-        if (state.step === 'wait_source') {
-            await tickSourcePoll(state);
-        } else if (state.step === 'wait_artifacts') {
-            await tickArtifactPoll(state);
-        } else if (state.step === 'generate_artifacts') {
-            console.log('[Alarm] Artifact start phase still in progress');
+    } catch (error) {
+        if (error?.code === 'PIPELINE_STALE_RUN') {
+            console.log(`[Alarm] Ignoring stale tick at ${step}`);
         } else {
-            console.log(`[Alarm] tick during non-polling step '${state.step}', ignoring`);
+            console.error(`[Alarm] Tick failed at ${step}:`, error);
         }
-    });
-
-    if (!ran) {
-        console.warn('[Alarm] Previous poll tick is still running; skipping overlap');
     }
-});
+}
+
+chrome.alarms.onAlarm.addListener(handlePollAlarm);
 
 async function reconcilePipelineRuntime() {
     const [state, alarm] = await Promise.all([
@@ -1199,8 +1221,19 @@ async function runPipeline(runId, pdfUrl, pageUrl, uploadFile = null, sourceType
 // Message handlers (from popup and content script)
 // =========================================================================
 
+function assertArtifactSelection(settings) {
+    if (settings.generateAudio !== false || [
+        'generateInfographic', 'generateVideo', 'generateReport', 'generateQuiz',
+        'generateFlashcards', 'generateSlideDeck', 'generateMindMap', 'generateDataTable',
+    ].some(key => !!settings[key])) return;
+    const error = new Error('Select at least one artifact before starting.');
+    error.code = 'NO_ARTIFACT_SELECTED';
+    throw error;
+}
+
 async function startPipelineRequest(message, uploadFile = null) {
     await bootReconciliationPromise;
+    assertArtifactSelection(await getSettings());
 
     if (uploadFile) {
         const decodedSize = decodedBase64ByteLength(uploadFile.fileData);

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -275,3 +275,21 @@ On September 4, 2026 at approximately 19:26 KST, the [public Chrome Web Store li
 The developer dashboard redirected to Google's Verify it is you sign-in page, so its publication status could not be independently confirmed. Dashboard verification remains outstanding until the publisher signs in again. No store mutation was performed.
 
 GitHub release ID `382447938` was still a v1.3.1 draft during this check. Its verified package remains ready for the next authorized publication step. It was not published, rebuilt, or submitted. Issue #14 still awaits post-v1.3.1-publication search observations.
+
+### v1.3.1 issue-fix candidate
+
+Later on September 4, the user authorized including issues #19 through #23 in the unsubmitted v1.3.1 draft. This supersedes the earlier instruction to retain its original ZIP unchanged. The v1.3.0 store package and public listing remain untouched.
+
+Notebook title and link attributes now escape quotes. New runs require at least one artifact before any remote creation, with another check before generation if settings change during ingestion. Legacy empty-task polling completes as source-import success before evaluating its timeout. Nonempty all-failed runs still fail. Alarm listeners contain stale ownership and unexpected errors, preserve overlap exclusion, and log cleanup-effect failures without overwriting replacement runs. The separate `suggested` and `pending_review` protocol question is tracked in #25 and is not changed here.
+
+Local PDF metadata reads use the first and last 256 KiB. Base64 metadata callers also bound decoding before allocating decoded bytes, with quartet alignment. XMP retains priority across both windows, and disjoint regions are not concatenated into a false metadata match. Metadata outside or crossing a window falls back to a useful filename or service-generated naming. Unused polling helpers, duplicate popup readers, and the redundant MIME branch were removed. The injected page reader remains separate.
+
+Local validation passed 81 deterministic tests and the Chrome smoke. The smoke exercises quoted title and link attributes, empty-task completion wording, and the real local-file popup entry point with a 40 MiB file and no supplied title. Metadata and signature reads totaled 525,312 bytes. The controlled server received all 41,943,040 bytes with matching SHA-256. The message was 55,924,192 bytes and the popup remained 344 pixels high at 360 pixels wide. This is controlled transport validation, not a claim of live Google ingestion or a universal memory improvement measurement.
+
+The replacement candidate ZIP has 20 unchanged allowlisted entries, version 1.3.1, and 67,482 bytes. Every decompressed entry matches the checkout and the checksum sidecar was verified. Its SHA-256 is below.
+
+```text
+bb4a0d28225801503656b892e101ede3bf632ee8194bfee44186fb09b9fdb343
+```
+
+The previous draft ZIP and checksum were retained locally under `dist/draft-backups/221d6f39610fb02bf/` after verifying the original digest. Exact-head and merged-main CI must pass before this candidate replaces the assets in release draft `382447938`. Record the final merged target and CI evidence with the draft update. Keep the release a draft and the store status **not submitted** until publication is authorized. The current bilingual release notes and prepared store copy include these fixes and the bounded naming behavior. Issue #14 still requires post-publication search evidence.

--- a/docs/releases/v1.3.1-store-listing.md
+++ b/docs/releases/v1.3.1-store-listing.md
@@ -8,6 +8,7 @@ ScholarRelay (Scholar Relay) is a PDF and research paper importer for Gemini Not
 
 - Import PDFs into NotebookLM from the current page or a local file.
 - Read paper titles from HTML metadata and try the PDF URL first. If no trustworthy title is found, Gemini Notebook names the notebook.
+- Local PDF titles use bounded head and tail metadata checks, with a useful filename or Gemini Notebook naming as fallback.
 - After a confirmed PDF URL import or processing failure, upload the PDF once into the same notebook. Grant download access or choose a file when prompted. Uncertain results and timeouts do not trigger another upload.
 - Choose audio, video, reports, quizzes, flashcards, infographics, slide decks, mind maps, and data tables. Set artifact language for audio, video, reports, infographics, slide decks, and data tables.
 - Add notebooks to a collection and follow progress after closing the popup. Stop Monitoring ends this workflow, but work already started in Gemini Notebook may continue.
@@ -24,6 +25,7 @@ ScholarRelay(Scholar Relay)는 Gemini Notebook(이전 명칭 NotebookLM)용 PDF 
 
 - 현재 페이지의 PDF나 로컬 PDF 파일을 NotebookLM으로 가져옵니다.
 - HTML 메타데이터에서 논문 제목을 찾고 PDF URL을 먼저 가져옵니다. 신뢰할 수 있는 제목이 없으면 Gemini Notebook이 노트북 이름을 정합니다.
+- 로컬 PDF 제목은 제한된 앞뒤 영역의 메타데이터에서 확인하며, 찾지 못하면 파일명 또는 Gemini Notebook의 자동 제목을 사용합니다.
 - PDF URL 가져오기나 처리 실패가 확인되면 같은 노트북에 PDF를 한 번 업로드합니다. 요청 시 다운로드 권한을 허용하거나 파일을 선택하세요. 결과가 불확실하거나 시간이 초과되면 추가 업로드를 실행하지 않습니다.
 - 오디오, 동영상, 보고서, 퀴즈, 플래시카드, 인포그래픽, 슬라이드, 마인드맵, 데이터 표를 선택합니다. 아티팩트 언어는 오디오, 동영상, 보고서, 인포그래픽, 슬라이드, 데이터 표에 적용됩니다.
 - 노트북을 컬렉션에 추가하고 팝업을 닫은 뒤에도 진행 상태를 확인합니다. Stop Monitoring은 이 워크플로를 중지하지만 Gemini Notebook에서 이미 시작된 작업은 계속될 수 있습니다.

--- a/docs/releases/v1.3.1.md
+++ b/docs/releases/v1.3.1.md
@@ -2,6 +2,11 @@
 
 ## 한국어
 
+- 따옴표가 포함된 노트북 제목과 링크를 올바르게 표시하고 새 탭 링크의 격리를 명시했습니다.
+- 아티팩트가 선택되지 않은 새 작업은 시작 전에 안내하고, 이전에 저장된 빈 아티팩트 작업은 가져오기 성공으로 마무리합니다.
+- 오래된 알람 작업은 안전하게 무시하고 예상하지 못한 오류는 단계와 함께 기록합니다.
+- 로컬 PDF 제목은 앞뒤의 제한된 영역에서 읽어 메모리 사용을 줄였습니다. 해당 영역에 제목이 없으면 기존 대체 이름 규칙을 사용합니다.
+- 사용하지 않는 폴링 함수와 중복 파일 읽기 코드를 제거했습니다.
 - 팝업의 가져오기, 업로드, 권한 요청 문구를 간결하게 다듬고 아티팩트 용어를 유지했습니다.
 - 아티팩트 언어를 공통 설정으로 옮겼습니다. 오디오를 꺼도 설정할 수 있으며 기존 저장값과 적용 범위는 그대로입니다.
 - 팝업을 닫아도 작업이 계속됨을 안내하고, Stop Monitoring을 눌러도 Gemini Notebook에서 이미 시작된 작업은 계속될 수 있음을 설명합니다.
@@ -10,6 +15,11 @@
 
 ## English
 
+- Render quoted notebook titles and links correctly and explicitly isolate new-tab links.
+- Reject new runs with no selected artifacts before starting, and complete saved empty-artifact runs as successful source imports.
+- Safely ignore stale alarm ticks and log unexpected errors with their workflow step.
+- Read local PDF titles from bounded head and tail regions to reduce memory use. Existing fallback naming applies when those regions contain no useful title.
+- Remove unused polling helpers and duplicate file-reading code.
 - Shorten popup import, upload, and permission wording while retaining artifact terminology.
 - Move artifact language into shared settings. It remains accessible with Audio disabled and keeps the saved value and existing scope.
 - Explain that work continues when the popup closes and that Stop Monitoring may leave work already started in Gemini Notebook running.

--- a/notebooklm-api.js
+++ b/notebooklm-api.js
@@ -747,11 +747,6 @@ async function addNotebookToCollection(collectionId, notebookId) {
   return confirmed;
 }
 
-function makeAbortError() {
-  const err = new Error('Pipeline monitoring aborted by user');
-  err.code = 'PIPELINE_ABORTED';
-  return err;
-}
 
 function normalizeBinaryPayload(fileData) {
   if (typeof fileData === 'string') {
@@ -1024,54 +1019,6 @@ async function createNote(notebookId, title = 'New Note', content = '') {
   return { id: String(noteId), title: String(title || '') };
 }
 
-/**
- * Wait for a source to become READY by polling.
- * Returns the ready source object.
- */
-async function waitForSourceReady(notebookId, sourceId, timeoutMs = 120000, intervalMs = 5000, shouldAbort = null) {
-  const start = Date.now();
-  const requestedSourceId = String(sourceId);
-  const normalizedRequestedId = extractFirstIdFromResult(requestedSourceId) || requestedSourceId;
-
-  while (Date.now() - start < timeoutMs) {
-    if (typeof shouldAbort === 'function' && shouldAbort()) {
-      throw makeAbortError();
-    }
-
-    const sources = await listSources(notebookId);
-    const source = sources.find(s => {
-      const currentId = String(s.id);
-      const normalizedCurrentId = extractFirstIdFromResult(currentId) || currentId;
-      return currentId === requestedSourceId || normalizedCurrentId === normalizedRequestedId;
-    });
-
-    if (!source) {
-      console.log(`[NotebookLM API] Source ${requestedSourceId} not visible yet, waiting ${intervalMs}ms...`);
-      if (typeof shouldAbort === 'function' && shouldAbort()) {
-        throw makeAbortError();
-      }
-      await sleep(intervalMs);
-      continue;
-    }
-
-    if (source.status === SourceStatus.READY) {
-      console.log(`[NotebookLM API] Source ${sourceId} is READY`);
-      return source;
-    }
-
-    if (source.status === SourceStatus.ERROR) {
-      throw new Error(`Source ${sourceId} processing failed`);
-    }
-
-    console.log(`[NotebookLM API] Source ${sourceId} status=${source.status}, waiting ${intervalMs}ms...`);
-    if (typeof shouldAbort === 'function' && shouldAbort()) {
-      throw makeAbortError();
-    }
-    await sleep(intervalMs);
-  }
-
-  throw new Error(`Source ${sourceId} timed out after ${timeoutMs}ms`);
-}
 
 /**
  * Get all source IDs from a notebook.
@@ -1781,41 +1728,7 @@ async function listArtifactStatuses(notebookId) {
   return statuses;
 }
 
-/**
- * Poll artifact status by listing all artifacts and finding the one we want.
- */
-async function pollArtifactStatus(notebookId, taskId) {
-  const statuses = await listArtifactStatuses(notebookId);
-  if (statuses.has(String(taskId))) {
-    return statuses.get(String(taskId));
-  }
-  return { taskId, status: 'pending' };
-}
 
-/**
- * Wait for an artifact generation to complete.
- */
-async function waitForArtifact(notebookId, taskId, timeoutMs = 600000, intervalMs = 15000) {
-  const start = Date.now();
-
-  while (Date.now() - start < timeoutMs) {
-    const status = await pollArtifactStatus(notebookId, taskId);
-
-    if (status.status === 'completed') {
-      console.log(`[NotebookLM API] Artifact ${taskId} completed`);
-      return status;
-    }
-
-    if (status.status === 'failed') {
-      throw new Error(`Artifact ${taskId} generation failed`);
-    }
-
-    console.log(`[NotebookLM API] Artifact ${taskId} status=${status.status}, waiting ${intervalMs}ms...`);
-    await sleep(intervalMs);
-  }
-
-  throw new Error(`Artifact ${taskId} timed out after ${timeoutMs}ms`);
-}
 
 // =========================================================================
 // Utilities
@@ -1882,7 +1795,6 @@ export {
   addFileSource,
   listSources,
   getNotebookTitle,
-  waitForSourceReady,
   generateAudio,
   generateVideo,
   generateReport,
@@ -1893,8 +1805,6 @@ export {
   generateMindMap,
   generateDataTable,
   listArtifactStatuses,
-  pollArtifactStatus,
-  waitForArtifact,
   ArtifactStatus,
   ArtifactTypeCode,
   AudioLength,

--- a/pdf-metadata.js
+++ b/pdf-metadata.js
@@ -1,13 +1,25 @@
+// Best-effort metadata only. Content outside these windows uses fallback naming.
+const PDF_METADATA_WINDOW_BYTES = 256 * 1024;
+
+function byteWindows(bytes) {
+  const size = PDF_METADATA_WINDOW_BYTES;
+  return bytes.length <= size * 2 ? [bytes] : [bytes.subarray(0, size), bytes.subarray(-size)];
+}
+
 function bytesFromPayload(payload) {
-  if (payload instanceof Uint8Array) return payload;
-  if (payload instanceof ArrayBuffer) return new Uint8Array(payload);
+  if (payload instanceof Uint8Array) return byteWindows(payload);
+  if (payload instanceof ArrayBuffer) return byteWindows(new Uint8Array(payload));
   if (typeof payload === 'string') {
-    const binary = atob(payload);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-    return bytes;
+    const compact = (payload.includes(',') ? payload.slice(payload.indexOf(',') + 1) : payload).replace(/\s+/g, '');
+    // Quartet alignment bounds decoding, including the final padded quartet.
+    const chars = Math.ceil(PDF_METADATA_WINDOW_BYTES / 3) * 4;
+    const parts = compact.length <= chars * 2 ? [compact] : [compact.slice(0, chars), compact.slice(-chars)];
+    return parts.map(part => {
+      const binary = atob(part);
+      return Uint8Array.from(binary, char => char.charCodeAt(0));
+    });
   }
-  return new Uint8Array();
+  return [];
 }
 
 function decodeXmlText(value) {
@@ -69,30 +81,49 @@ function isUsefulTitle(value) {
 }
 
 function extractPdfMetadataTitle(payload) {
-  const bytes = bytesFromPayload(payload);
-  if (!bytes.length) return null;
+  return titleFromWindows(bytesFromPayload(payload));
+}
 
-  const utf8 = new TextDecoder('utf-8', { fatal: false }).decode(bytes);
-  const dcTitle = utf8.match(/<dc:title\b[^>]*>([\s\S]*?)<\/dc:title>/i)?.[1];
-  const xmpValue = dcTitle?.match(/<rdf:li\b[^>]*>([\s\S]*?)<\/rdf:li>/i)?.[1] || dcTitle;
-  const xmpTitle = normalizeTitle(decodeXmlText(xmpValue));
-  if (isUsefulTitle(xmpTitle)) return xmpTitle;
+function titleFromWindows(windows) {
+  // Preserve XMP precedence across both windows, without joining unrelated bytes.
+  for (const bytes of windows) {
+    const utf8 = new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+    const dcTitle = utf8.match(/<dc:title\b[^>]*>([\s\S]*?)<\/dc:title>/i)?.[1];
+    const xmpValue = dcTitle?.match(/<rdf:li\b[^>]*>([\s\S]*?)<\/rdf:li>/i)?.[1] || dcTitle;
+    const xmpTitle = normalizeTitle(decodeXmlText(xmpValue));
+    if (isUsefulTitle(xmpTitle)) return xmpTitle;
+  }
 
-  const latin1 = new TextDecoder('windows-1252').decode(bytes);
-  const literalMatch = latin1.match(/\/Title\s*\(((?:\\.|[^\\)])*)\)/s);
-  const literalTitle = normalizeTitle(literalMatch ? decodePdfLiteral(literalMatch[1]) : '');
-  if (isUsefulTitle(literalTitle)) return literalTitle;
+  const decoded = windows.map(bytes => new TextDecoder('windows-1252').decode(bytes));
+  for (const latin1 of decoded) {
+    const literalMatch = latin1.match(/\/Title\s*\(((?:\\.|[^\\)])*)\)/s);
+    const literalTitle = normalizeTitle(literalMatch ? decodePdfLiteral(literalMatch[1]) : '');
+    if (isUsefulTitle(literalTitle)) return literalTitle;
+  }
 
-  const hexMatch = latin1.match(/\/Title\s*<([0-9a-f\s]+)>/i);
-  if (hexMatch) {
-    const hex = hexMatch[1].replace(/\s+/g, '');
-    const hexBytes = new Uint8Array((hex.length / 2) | 0);
-    for (let i = 0; i < hexBytes.length; i++) hexBytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
-    const hexTitle = normalizeTitle(decodePdfLiteral(String.fromCharCode(...hexBytes)));
-    if (isUsefulTitle(hexTitle)) return hexTitle;
+  for (const latin1 of decoded) {
+    const hexMatch = latin1.match(/\/Title\s*<([0-9a-f\s]+)>/i);
+    if (hexMatch) {
+      const hex = hexMatch[1].replace(/\s+/g, '');
+      const hexBytes = new Uint8Array((hex.length / 2) | 0);
+      for (let i = 0; i < hexBytes.length; i++) hexBytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+      const hexTitle = normalizeTitle(decodePdfLiteral(Array.from(hexBytes, byte => String.fromCharCode(byte)).join('')));
+      if (isUsefulTitle(hexTitle)) return hexTitle;
+    }
   }
 
   return null;
+}
+
+async function choosePdfFileTitle({ file, pageTitle } = {}) {
+  const normalizedPageTitle = normalizeTitle(pageTitle);
+  if (isUsefulTitle(normalizedPageTitle)) return { title: normalizedPageTitle, source: 'page_metadata' };
+  const size = PDF_METADATA_WINDOW_BYTES;
+  const slices = file.size <= size * 2 ? [file] : [file.slice(0, size), file.slice(-size)];
+  const windows = await Promise.all(slices.map(async slice => new Uint8Array(await slice.arrayBuffer())));
+  const title = titleFromWindows(windows);
+  if (title) return { title, source: 'pdf_metadata' };
+  return choosePdfTitle({ filename: file.name });
 }
 
 function titleFromFilename(filename) {
@@ -116,4 +147,4 @@ function choosePdfTitle({ payload, pageTitle, filename } = {}) {
   return { title: null, source: 'notebooklm' };
 }
 
-export { choosePdfTitle, extractPdfMetadataTitle, isUsefulTitle, titleFromFilename };
+export { choosePdfTitle, choosePdfFileTitle, extractPdfMetadataTitle, isUsefulTitle, titleFromFilename, PDF_METADATA_WINDOW_BYTES };

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,5 @@
 import { inspectPaperPage } from './content.js';
-import { choosePdfTitle } from './pdf-metadata.js';
+import { choosePdfTitle, choosePdfFileTitle } from './pdf-metadata.js';
 import { directDetectionMatchesTab } from './detection-policy.js';
 import {
     MAX_PDF_UPLOAD_BYTES,
@@ -493,14 +493,16 @@ function renderProgress(state) {
 
     let bottomHtml = '';
     if (state.notebookUrl) {
-        bottomHtml += `<a class="notebook-link" href="${state.notebookUrl}" target="_blank">📓 Open in Gemini Notebook</a>`;
+        bottomHtml += `<a class="notebook-link" href="${escapeHtml(state.notebookUrl)}" target="_blank" rel="noopener noreferrer">📓 Open in Gemini Notebook</a>`;
     }
     if (state.status === 'completed') {
         const tasks = state.tasks || [];
         const totalCount = tasks.length;
         const completedCount = tasks.filter(t => t.status === 'completed').length;
         const failedCount = tasks.filter(t => t.status === 'failed').length;
-        const summaryMsg = failedCount > 0
+        const summaryMsg = totalCount === 0
+            ? 'Source imported. No artifacts requested.'
+            : failedCount > 0
             ? `${completedCount}/${totalCount} artifacts ready (${failedCount} failed).`
             : `${completedCount} artifact${completedCount !== 1 ? 's' : ''} ready!`;
         bottomHtml += `
@@ -666,12 +668,11 @@ async function startPipelineFile(file, pageUrl, sourceTitle = null) {
         assertPdfUploadSize(file.size);
         const signature = await file.slice(0, 1024).arrayBuffer();
         if (!hasPdfSignature(signature)) throw new Error("This file isn't a valid PDF. Choose another file.");
-        const fileDataBase64 = await readFileAsBase64(file);
-        const selectedTitle = choosePdfTitle({
-            payload: fileDataBase64,
+        const selectedTitle = await choosePdfFileTitle({
+            file,
             pageTitle: sourceTitle,
-            filename: file.name,
         });
+        const fileDataBase64 = await readFileAsBase64(file);
         console.log(`[Popup] Notebook title source: ${selectedTitle.source}`);
         const response = await chrome.runtime.sendMessage({
             type: 'START_PIPELINE_FILE',
@@ -701,19 +702,6 @@ async function startPipelineFile(file, pageUrl, sourceTitle = null) {
         showError(error?.message || 'Could not upload the selected PDF.');
         return false;
     }
-}
-
-function blobToBase64(blob) {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => {
-            const result = String(reader.result || '');
-            const commaIdx = result.indexOf(',');
-            resolve(commaIdx >= 0 ? result.substring(commaIdx + 1) : result);
-        };
-        reader.onerror = () => reject(reader.error || new Error('Failed to read PDF blob'));
-        reader.readAsDataURL(blob);
-    });
 }
 
 function filenameFromUrl(url) {
@@ -795,7 +783,7 @@ async function tryDirectTabPdfRead(tab, preferredPdfUrl = null) {
         const mimeType = response.headers.get('content-type') || 'application/pdf';
         if (!hasPdfSignature(bytes)) return { ok: false, error: 'Current tab content is not a valid PDF' };
         const blob = new Blob([bytes], { type: mimeType });
-        const fileDataBase64 = await blobToBase64(blob);
+        const fileDataBase64 = await readFileAsBase64(blob);
         return {
             ok: true,
             fileDataBase64,
@@ -1108,7 +1096,7 @@ async function getState() {
 function escapeHtml(str) {
     const div = document.createElement('div');
     div.textContent = str;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
 window.addEventListener('unload', stopPolling);

--- a/scripts/smoke-extension.mjs
+++ b/scripts/smoke-extension.mjs
@@ -254,6 +254,8 @@ try {
   await writeFile(apiPath, (await readFile(apiPath, 'utf8'))
     .replace("const DEFAULT_BASE_URL = 'https://notebook.google.com';", `const DEFAULT_BASE_URL = '${origin}';`)
     .replace("const LEGACY_BASE_URL = 'https://notebooklm.google.com';", `const LEGACY_BASE_URL = '${origin}';`));
+  const popupPath = join(extensionRoot, 'popup.js');
+  await writeFile(popupPath, `${await readFile(popupPath, 'utf8')}\nglobalThis.__smoke = { startPipelineFile };\n`);
 
   const chromePath = await resolveChrome();
   chrome = spawn(chromePath, [
@@ -368,6 +370,16 @@ try {
   assert(layout.resultBottom < 600 && layout.linkBottom < 600 && layout.collapsed, 'Results are not immediately visible');
   console.log(`Completed popup layout: ${JSON.stringify(layout)}`);
 
+  const quotedTitle = `A "quoted" title 'with' <markup> & symbols`;
+  const quotedUrl = `${origin}/notebook/smoke?q="quoted"&other='value'`;
+  await evaluate(popup, `chrome.storage.local.set({pipelineState:${JSON.stringify({ ...completedState, notebookTitle: quotedTitle, notebookUrl: quotedUrl, tasks: [] })}})`);
+  await reload(popup);
+  const escaped = await evaluate(popup, `({title:document.querySelector('.nb-title').getAttribute('title'),text:document.querySelector('.nb-title').textContent,attributes:document.querySelector('.nb-title').getAttributeNames(),href:document.querySelector('.notebook-link').getAttribute('href'),rel:document.querySelector('.notebook-link').rel,summary:document.querySelector('.completed-box').innerText})`);
+  assert(escaped.title === quotedTitle && escaped.text === quotedTitle, 'Quoted notebook title was corrupted');
+  assert(escaped.attributes.length === 2 && escaped.href === quotedUrl, 'Title or URL created unexpected markup');
+  assert(escaped.rel.includes('noopener') && escaped.rel.includes('noreferrer'), 'Notebook link lacks isolation');
+  assert(escaped.summary.includes('Source imported. No artifacts requested.'), 'Empty-task completion claims artifact output');
+
   // Exercise the real Chrome message bridge and the complete file upload client.
   await evaluate(popup, `chrome.storage.local.set({pipelineState:{status:'idle'}})`);
   const size = 40 * 1024 * 1024;
@@ -378,17 +390,26 @@ try {
   const baselineHeap = await popup.call('Runtime.getHeapUsage');
   const transfer = await evaluate(popup, `(async()=>{
     const bytes=new Uint8Array(${size}).fill(32); bytes.set(new TextEncoder().encode('%PDF-1.7\\n'));
-    const fileDataBase64=await new Promise(resolve=>{const reader=new FileReader();reader.onload=()=>resolve(reader.result.split(',')[1]);reader.readAsDataURL(new Blob([bytes],{type:'application/pdf'}));});
     let last=performance.now(),maxGapMs=0,ticks=0;
     const timer=setInterval(()=>{const now=performance.now();maxGapMs=Math.max(maxGapMs,now-last);last=now;ticks++;},25);
-    const message={type:'START_PIPELINE_FILE',fileName:'large-smoke.pdf',fileDataBase64,sourceTitle:'Large PDF validation'};
-    const messageBytes=new TextEncoder().encode(JSON.stringify(message)).byteLength;
-    const response=await chrome.runtime.sendMessage(message);
-    clearInterval(timer);
-    return {response,messageBytes,maxGapMs,ticks};
+    const file=new File([bytes],'paper.pdf',{type:'application/pdf'});
+    let metadataReadBytes=0,messageBytes=0;
+    const slice=file.slice.bind(file);
+    file.slice=(...args)=>{const part=slice(...args);metadataReadBytes+=part.size;return part;};
+    file.arrayBuffer=()=>{throw new Error('Full-file metadata read');};
+    const send=chrome.runtime.sendMessage.bind(chrome.runtime);
+    chrome.runtime.sendMessage=(message,...args)=>{
+      if(message.type==='START_PIPELINE_FILE') messageBytes=new TextEncoder().encode(JSON.stringify(message)).byteLength;
+      return send(message,...args);
+    };
+    try {
+      const ok=await globalThis.__smoke.startPipelineFile(file,null);
+      return {response:{ok},messageBytes,maxGapMs,ticks,metadataReadBytes};
+    } finally {clearInterval(timer);chrome.runtime.sendMessage=send;}
   })()`);
   assert(transfer.response.ok, `Large PDF start failed: ${JSON.stringify(transfer.response)}`);
   assert(transfer.messageBytes < 64 * 1024 * 1024, 'Large PDF message exceeds Chrome limit');
+  assert(transfer.metadataReadBytes === 2 * 256 * 1024 + 1024, 'Large local metadata read was not bounded');
   const targets = await browserConnection.call('Target.getTargets');
   const workerTarget = targets.targetInfos.find(target => target.type === 'service_worker' && target.url.includes(extensionId));
   const workerAttachment = workerTarget ? await browserConnection.call('Target.attachToTarget', { targetId: workerTarget.targetId, flatten: true }) : null;
@@ -414,7 +435,7 @@ try {
     return chrome.runtime.sendMessage({type:'START_PIPELINE_FILE',fileName:'too-large.pdf',fileDataBase64:b64});
   })()`);
   assert(!rejected.ok && rejected.code === 'PDF_TOO_LARGE', '40 MiB plus one byte was not rejected');
-  console.log(`40 MiB transfer: ${JSON.stringify({messageBytes:transfer.messageBytes,elapsedMs:Date.now()-started,maxTimerGapMs:transfer.maxGapMs,peak,sha256:imports.uploadedHash})}`);
+  console.log(`40 MiB transfer: ${JSON.stringify({messageBytes:transfer.messageBytes,metadataReadBytes:transfer.metadataReadBytes,elapsedMs:Date.now()-started,maxTimerGapMs:transfer.maxGapMs,peak,sha256:imports.uploadedHash})}`);
 
   console.log('Chrome extension smoke test passed.');
 } finally {

--- a/tests/background-lifecycle.test.js
+++ b/tests/background-lifecycle.test.js
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+import { webcrypto } from 'node:crypto';
+import * as api from '../notebooklm-api.js';
+import * as runtime from '../runtime-policy.js';
+import * as fallback from '../source-import.js';
+import * as detection from '../detection-policy.js';
+import * as pdf from '../pdf-file-policy.js';
+import * as permissions from '../site-permissions.js';
+
+// Run the shipped worker with real policy modules and controlled browser/service IO.
+const source = (await readFile(new URL('../background.js', import.meta.url), 'utf8'))
+  .replace(/^import\s+[\s\S]*?from\s+'[^']+';\r?\n/gm, '');
+
+async function worker() {
+  const data = { pipelineState: { status: 'idle' }, userSettings: { chimeEnabled: false, notificationEnabled: false } };
+  const logs = [];
+  let listener;
+  const hooks = {};
+  const noop = async () => {};
+  const event = { addListener() {} };
+  const apiMocks = Object.fromEntries(Object.entries(api).map(([key, value]) => [key,
+    typeof value === 'function' ? () => { throw new Error(`Unexpected service call ${key}`); } : value]));
+  const context = vm.createContext({
+    ...apiMocks, ...runtime, ...fallback, ...detection, ...pdf, ...permissions,
+    console: Object.fromEntries(['log', 'warn', 'error'].map(level => [level, (...args) => logs.push([level, ...args])])),
+    crypto: webcrypto, URL, TextEncoder, TextDecoder, Uint8Array, ArrayBuffer, atob, btoa, setTimeout, clearTimeout,
+    chrome: {
+      storage: { local: {
+        async get(key) { const result = structuredClone({ [key]: data[key] }); await hooks.read?.(key); return result; },
+        async set(update) { await hooks.write?.(update); Object.assign(data, structuredClone(update)); },
+      } },
+      alarms: { get: async () => null, clear: noop, create: noop, onAlarm: { addListener(fn) { listener = fn; } } },
+      action: { setBadgeText: noop, setBadgeBackgroundColor: noop },
+      runtime: { onMessage: event },
+      notifications: { onClicked: event, onButtonClicked: event, onClosed: event, create: noop },
+      tabs: { create: noop },
+    },
+  });
+  vm.runInContext(source, context);
+  await vm.runInContext('bootReconciliationPromise', context);
+  const functions = vm.runInContext('({startPipelineRequest, tickArtifactPoll, tickSourcePoll})', context);
+  return { data, logs, hooks, context, listener, ...functions };
+}
+
+function running(tasks = []) {
+  return { status: 'running', runId: 'old', step: 'wait_artifacts', notebookId: 'notebook',
+    stepStartedAt: new Date().toISOString(), tasks };
+}
+
+test('backend rejects no-artifact starts without creating or claiming a notebook', async () => {
+  const w = await worker();
+  Object.assign(w.data.userSettings, { generateAudio: false, generateInfographic: false });
+  await assert.rejects(w.startPipelineRequest({ pdfUrl: 'https://example.org/paper.pdf' }),
+    { code: 'NO_ARTIFACT_SELECTED' });
+  assert.equal(w.data.pipelineState.status, 'idle');
+});
+
+test('legacy empty tasks complete before timeout without listing artifacts', async () => {
+  const w = await worker();
+  w.data.pipelineState = { ...running(), stepStartedAt: '2000-01-01T00:00:00Z' };
+  await w.listener({ name: runtime.PIPELINE_ALARM_NAME });
+  assert.equal(w.data.pipelineState.status, 'completed');
+  assert.match(w.data.pipelineState.stepDetail, /Source imported successfully/);
+});
+
+test('nonempty all-failed tasks still fail, while partial success completes', async () => {
+  for (const tasks of [[{ status: 'failed' }], [{ status: 'completed' }, { status: 'failed' }]]) {
+    const w = await worker();
+    w.context.listArtifactStatuses = async () => new Map();
+    w.data.pipelineState = running(tasks);
+    await w.listener({ name: runtime.PIPELINE_ALARM_NAME });
+    assert.equal(w.data.pipelineState.status, tasks.length === 1 ? 'error' : 'completed');
+  }
+});
+
+test('alarm swallows ownership races and preserves the replacement run', async () => {
+  for (const step of ['wait_source', 'wait_artifacts']) {
+    const w = await worker();
+    w.data.pipelineState = { ...running(), step };
+    w.hooks.read = key => {
+      if (key !== 'pipelineState') return;
+      w.hooks.read = null;
+      w.data.pipelineState = { ...running(), runId: 'replacement', step };
+    };
+    await assert.doesNotReject(w.listener({ name: runtime.PIPELINE_ALARM_NAME }));
+    assert.equal(w.data.pipelineState.runId, 'replacement');
+    assert.equal(w.data.pipelineState.status, 'running');
+    assert.ok(w.logs.some(row => row[1].includes('Ignoring stale tick')));
+  }
+});
+
+test('alarm logs unexpected errors and unlocks for the next tick', async () => {
+  const w = await worker();
+  w.data.pipelineState = running();
+  w.hooks.write = () => { throw new Error('Storage unavailable'); };
+  await assert.doesNotReject(w.listener({ name: runtime.PIPELINE_ALARM_NAME }));
+  assert.ok(w.logs.some(row => row[0] === 'error' && row[1].includes('wait_artifacts')));
+  w.hooks.write = null;
+  await w.listener({ name: runtime.PIPELINE_ALARM_NAME });
+  assert.equal(w.data.pipelineState.status, 'completed');
+});
+
+test('alarm overlap warning remains reachable', async () => {
+  const w = await worker();
+  w.data.pipelineState = running();
+  let release;
+  w.hooks.read = key => {
+    if (key !== 'pipelineState') return;
+    w.hooks.read = null;
+    return new Promise(resolve => { release = resolve; });
+  };
+  const first = w.listener({ name: runtime.PIPELINE_ALARM_NAME });
+  while (!release) await Promise.resolve();
+  await w.listener({ name: runtime.PIPELINE_ALARM_NAME });
+  assert.ok(w.logs.some(row => row[1].includes('skipping overlap')));
+  release();
+  await first;
+});
+
+test('alarm cleanup failures are logged rather than lost in an effect result', async () => {
+  const w = await worker();
+  w.context.chrome.alarms.clear = async () => { throw new Error('Alarm unavailable'); };
+  await assert.doesNotReject(w.listener({ name: runtime.PIPELINE_ALARM_NAME }));
+  assert.ok(w.logs.some(row => row[0] === 'error' && row[2]?.message === 'Alarm unavailable'));
+});
+
+test('settings changed during ingestion stop generation without deleting the imported notebook', async () => {
+  const w = await worker();
+  w.data.pipelineState = { ...running(), step: 'wait_source', sourceId: 'source' };
+  Object.assign(w.data.userSettings, { generateAudio: false, generateInfographic: false });
+  w.context.listSources = async () => [{ id: 'source', status: api.SourceStatus.READY }];
+  w.context.getNotebookTitle = async () => 'Imported paper';
+  await w.listener({ name: runtime.PIPELINE_ALARM_NAME });
+  assert.equal(w.data.pipelineState.status, 'error');
+  assert.match(w.data.pipelineState.error, /Select at least one artifact/);
+  assert.equal(w.data.pipelineState.notebookId, 'notebook');
+});

--- a/tests/pdf-metadata.test.js
+++ b/tests/pdf-metadata.test.js
@@ -6,6 +6,8 @@ import {
   extractPdfMetadataTitle,
   isUsefulTitle,
   titleFromFilename,
+  choosePdfFileTitle,
+  PDF_METADATA_WINDOW_BYTES,
 } from '../pdf-metadata.js';
 
 const bytes = text => new TextEncoder().encode(text);
@@ -50,4 +52,55 @@ test('allows NotebookLM to name the notebook when no trustworthy title exists', 
 test('a useful HTML title avoids inspecting PDF bytes', () => {
   assert.deepEqual(choosePdfTitle({ pageTitle: 'The actual article title', payload: 'not valid base64' }),
     { title: 'The actual article title', source: 'page_metadata' });
+});
+
+test('bounded metadata preserves tail XMP precedence and normalizes Base64 input', () => {
+  const payload = new Uint8Array(PDF_METADATA_WINDOW_BYTES * 4).fill(32);
+  payload.set(bytes('/Title (Head Info title)'));
+  payload.set(bytes('<dc:title>Tail XMP title</dc:title>'), payload.length - 100);
+  assert.equal(extractPdfMetadataTitle(payload), 'Tail XMP title');
+  assert.equal(extractPdfMetadataTitle(payload.buffer), 'Tail XMP title');
+  const base64 = Buffer.from(payload).toString('base64');
+  assert.equal(extractPdfMetadataTitle(`data:application/pdf;base64,\n${base64}\n`), 'Tail XMP title');
+});
+
+test('metadata outside the windows or crossing a cut uses fallback naming', async () => {
+  for (const offset of [PDF_METADATA_WINDOW_BYTES * 2, PDF_METADATA_WINDOW_BYTES - 10]) {
+    const payload = new Uint8Array(PDF_METADATA_WINDOW_BYTES * 4).fill(32);
+    payload.set(bytes('/Title (Outside scanned region)\n'), offset);
+    assert.equal(extractPdfMetadataTitle(payload), null);
+    assert.equal(extractPdfMetadataTitle(Buffer.from(payload).toString('base64')), null);
+    assert.deepEqual(await choosePdfFileTitle({ file: new File([payload], 'paper.pdf') }),
+      { title: null, source: 'notebooklm' });
+  }
+});
+
+test('large local file metadata reads only two bounded slices', async () => {
+  const reads = [];
+  const file = {
+    size: 40 * 1024 * 1024, name: 'paper.pdf',
+    arrayBuffer() { throw new Error('Full-file metadata read'); },
+    slice(start, end) {
+      const length = start < 0 ? -start : end - start;
+      reads.push(length);
+      return new Blob([new Uint8Array(length)]);
+    },
+  };
+  assert.deepEqual(await choosePdfFileTitle({ file }), { title: null, source: 'notebooklm' });
+  assert.deepEqual(reads, [PDF_METADATA_WINDOW_BYTES, PDF_METADATA_WINDOW_BYTES]);
+  reads.length = 0;
+  assert.equal((await choosePdfFileTitle({ file, pageTitle: 'Useful HTML title' })).source, 'page_metadata');
+  assert.equal(reads.length, 0);
+});
+
+test('Base64 metadata decoding is bounded before allocating decoded bytes', () => {
+  const original = globalThis.atob;
+  const lengths = [];
+  globalThis.atob = value => { lengths.push(value.length); return original(value); };
+  try {
+    const payload = Buffer.alloc(4 * PDF_METADATA_WINDOW_BYTES, 32).toString('base64');
+    assert.equal(extractPdfMetadataTitle(payload), null);
+    assert.equal(lengths.length, 2);
+    assert.ok(lengths.every(length => length <= Math.ceil(PDF_METADATA_WINDOW_BYTES / 3) * 4));
+  } finally { globalThis.atob = original; }
 });


### PR DESCRIPTION
Fix quoted popup attributes, reject empty artifact selections before remote creation, finish legacy empty-task runs, contain alarm errors, and bound PDF metadata reads. Remove unused polling and duplicate reader code. Retain v1.3.1 as an unsubmitted draft.

Validation includes 81 tests, Chrome smoke with the real 40 MiB local-file path, syntax checks, and a verified 20-file ZIP. Preserve the old draft package locally. The protocol status question is tracked separately in #25.

Closes #19
Closes #20
Closes #21
Closes #22
Closes #23