### PR TITLE
Record v1.3.2 draft verification

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -327,3 +327,19 @@ Local checks include 87 deterministic tests, complete generated catalogs and pla
 The first local smoke inherited the system language and exposed an English-only harness assumption. Its baseline now explicitly requests English, followed by deterministic seven-locale checks. Background-tab screenshot capture required bringing the isolated test tab to the front. These were harness corrections, not reasons to alter production language selection.
 
 The candidate remains a draft until its publication step is authorized. Record exact-head CI, merged-main CI, final package bytes and digest below before preparing the release draft. Keep #14 open for post-publication search evidence and #25 open for protocol verification.
+
+### v1.3.2 verified draft
+
+[PR #29](https://github.com/mahlernim/scholar-relay/pull/29) closed #28 after both exact-head CI jobs passed at `b83ead784baba7d1d436b66a7d275ca8b0dde2ae` in [run 33866885722](https://github.com/mahlernim/scholar-relay/actions/runs/33866885722). Both merged-main jobs passed at `2a7ef7a3265d8c99da83ef525059ecf407955d03` in [run 33867047014](https://github.com/mahlernim/scholar-relay/actions/runs/33867047014).
+
+The canonical ZIP was built from that merged Windows checkout. It contains 26 allowlisted runtime files, embeds version 1.3.2, and is 114,101 bytes. Every decompressed file matches the release checkout and the checksum sidecar was verified. The ZIP and sidecar were uploaded to [GitHub draft 382668031](https://github.com/mahlernim/scholar-relay/releases/tag/untagged-e0440ac9665a9f716d89). Both uploaded asset digests match their local files. The ZIP SHA-256 is below.
+
+```text
+5921bf2adea872eb4ea23378d3399f925f1775852a287581bfc461a6716963a5
+```
+
+The final catalogs contain 198 UI messages per locale plus name and summary metadata. All 87 tests pass, including localized worker notifications and unchanged diagnostics. Seven-locale Chrome smoke and the original real 40 MiB transfer pass locally and in hosted CI. The global and six localized pairs of store screenshots were regenerated and visually inspected. The capture tool now checks caption/image bounds and constrains grid columns after Korean headline overflow was detected and corrected.
+
+A fresh release read confirmed `isDraft = true` and target `2a7ef7a3265d8c99da83ef525059ecf407955d03`. Version 1.3.2 is **not published and not submitted to the store**. No developer-console mutation occurred during localization preparation. The earlier observed store draft remains 1.3.1 unless subsequently changed outside this task. Published v1.3.1 still has its original `e5c41f44...82fb94` digest, verified locally and against GitHub.
+
+For the next authorized publication step, use this exact ZIP without rebuilding. Use [the seven descriptions](releases/v1.3.2-store-listing.md), global screenshots for English, and `docs/store-assets/<locale>/` for Korean, Japanese, Spanish, French, German, and Brazilian Portuguese. Verify package version and all seven languages in the dashboard before submission. Record submission and eventual public availability separately. Issues #14 and #25 remain open for their existing follow-ups.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -332,7 +332,7 @@ The candidate remains a draft until its publication step is authorized. Record e
 
 [PR #29](https://github.com/mahlernim/scholar-relay/pull/29) closed #28 after both exact-head CI jobs passed at `b83ead784baba7d1d436b66a7d275ca8b0dde2ae` in [run 33866885722](https://github.com/mahlernim/scholar-relay/actions/runs/33866885722). Both merged-main jobs passed at `2a7ef7a3265d8c99da83ef525059ecf407955d03` in [run 33867047014](https://github.com/mahlernim/scholar-relay/actions/runs/33867047014).
 
-The canonical ZIP was built from that merged Windows checkout. It contains 26 allowlisted runtime files, embeds version 1.3.2, and is 114,101 bytes. Every decompressed file matches the release checkout and the checksum sidecar was verified. The ZIP and sidecar were uploaded to [GitHub draft 382668031](https://github.com/mahlernim/scholar-relay/releases/tag/untagged-e0440ac9665a9f716d89). Both uploaded asset digests match their local files. The ZIP SHA-256 is below.
+The canonical ZIP was built from that merged Windows checkout. It contains 26 allowlisted runtime files, embeds version 1.3.2, and is 114,101 bytes. Every decompressed file matches the release checkout and the checksum sidecar was verified. The ZIP and sidecar were uploaded to GitHub draft `382668031` in [the release list](https://github.com/mahlernim/scholar-relay/releases). Both uploaded asset digests match their local files. The ZIP SHA-256 is below.
 
 ```text
 5921bf2adea872eb4ea23378d3399f925f1775852a287581bfc461a6716963a5

--- a/docs/releases/v1.3.2.md
+++ b/docs/releases/v1.3.2.md
@@ -19,3 +19,15 @@ The published v1.3.1 ZIP remains unchanged. This release is prepared as a draft 
 - 번역 누락, 대체 문자열, 좁은 팝업 레이아웃과 기존 수명 주기 및 40 MiB 전송 안전장치를 확인합니다.
 
 이미 공개된 v1.3.1 ZIP은 변경하지 않습니다. 이 릴리스는 공개 및 스토어 제출 단계가 승인될 때까지 초안으로 준비합니다. 스토어 초안은 공개된 업데이트가 아닙니다.
+
+## Verification / 검증
+
+All 87 tests, seven-locale Chrome smoke, and the 40 MiB transfer pass. Both [PR-head CI](https://github.com/mahlernim/scholar-relay/actions/runs/33866885722) and [merged-main CI](https://github.com/mahlernim/scholar-relay/actions/runs/33867047014) passed. Release target is `2a7ef7a3265d8c99da83ef525059ecf407955d03`. The ZIP contains 26 runtime files and 114,101 bytes. Embedded version, decompressed file bytes, and uploaded digest were verified.
+
+87개 테스트, 7개 언어 Chrome 스모크 테스트, 40 MiB 전송 검증을 통과했습니다. 위 링크의 PR 최종 커밋 CI와 병합 후 main CI를 모두 통과했습니다. 릴리스 대상은 `2a7ef7a3265d8c99da83ef525059ecf407955d03`이며 ZIP은 런타임 파일 26개, 114,101바이트입니다. 내부 버전, 압축 해제된 파일 바이트, 업로드된 파일의 해시를 확인했습니다.
+
+SHA-256
+
+```text
+5921bf2adea872eb4ea23378d3399f925f1775852a287581bfc461a6716963a5
+```


### PR DESCRIPTION
Record PR #29 and merged-main CI, the canonical ZIP digest, seven-language screenshots, and GitHub draft status. Version 1.3.2 is not published or submitted. No runtime changes. Keeps #14 and #25 open for their existing follow-ups.