### PR TITLE
Add workflow lint and secret scanning to CI

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,75 @@
+name: Repository preflight
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preflight-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: Workflow lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install actionlint 1.7.12
+        shell: bash
+        run: |
+          tool_dir="$RUNNER_TEMP/actionlint"
+          mkdir -p "$tool_dir"
+          curl --fail --silent --show-error --location --retry 3 \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz \
+            --output "$tool_dir/actionlint.tar.gz"
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  $tool_dir/actionlint.tar.gz" | sha256sum --check --strict
+          tar -xzf "$tool_dir/actionlint.tar.gz" -C "$tool_dir" actionlint
+      - name: Check GitHub Actions workflows
+        shell: bash
+        # Keep scope consistent with local preflight; optional script linters are separate.
+        run: '"$RUNNER_TEMP/actionlint/actionlint" -shellcheck= -pyflakes='
+
+  gitleaks:
+    name: Secret scan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out source and history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Gitleaks 8.30.1
+        shell: bash
+        run: |
+          tool_dir="$RUNNER_TEMP/gitleaks"
+          mkdir -p "$tool_dir"
+          curl --fail --silent --show-error --location --retry 3 \
+            https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+            --output "$tool_dir/gitleaks.tar.gz"
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  $tool_dir/gitleaks.tar.gz" | sha256sum --check --strict
+          tar -xzf "$tool_dir/gitleaks.tar.gz" -C "$tool_dir" gitleaks
+      - name: Scan for secrets
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+            "$RUNNER_TEMP/gitleaks/gitleaks" git . --redact=100 --no-banner \
+              --log-opts="$base..$HEAD_SHA"
+          else
+            # Main and manually dispatched runs also check existing history.
+            "$RUNNER_TEMP/gitleaks/gitleaks" git . --redact=100 --no-banner
+          fi


### PR DESCRIPTION
Adds Workflow lint and Secret scan checks for pull requests, pushes to main, and manual runs. actionlint checks all GitHub Actions workflows. Gitleaks scans the PR commit range, including secrets removed in later commits; main and manual runs scan existing history with findings redacted.

Checkout is pinned to a commit with read-only permissions and persisted credentials disabled. Downloads of actionlint 1.7.12 and Gitleaks 8.30.1 are pinned and SHA-256 verified. Existing application tests, packaging, and release workflows are unchanged. Optional ShellCheck/Pyflakes integration remains outside this change.

Validation: current workflows and fetched history pass local checks without exclusions. The same workflow passed both hosted preflight jobs in ha-busan-city-gas. A synthetic Git fixture verified a clean PR, detection of a subsequently removed secret, push/manual history scanning, invalid-base failure, and output redaction.