### PR TITLE
Fix queued PDF and worker recovery failures

### DIFF
--- a/background.js
+++ b/background.js
@@ -1017,11 +1017,16 @@ async function dispatchNextJob() {
         if (error?.code !== 'PIPELINE_STALE_RUN') await failPipeline(job.runId, error.message);
     } finally {
         const current = await getState(job.runId);
-        if (!['queued', 'auth', 'create_notebook', 'add_source', 'download_pdf', 'upload_pdf', 'queued_pdf'].includes(current.step)) {
+        if (!shouldRetainJobPdf(current)) {
             await releaseJobPdf(job.runId);
         }
         dispatchAgain = true;
     }
+}
+
+function shouldRetainJobPdf(job) {
+    return ['queued', 'auth', 'create_notebook', 'add_source', 'download_pdf', 'upload_pdf', 'queued_pdf', 'wait_pdf_access']
+        .includes(job?.step);
 }
 
 async function releaseJobPdf(runId) {
@@ -1038,7 +1043,7 @@ async function releaseJobPdf(runId) {
 async function handlePollAlarm(alarm) {
     if (alarm.name !== ALARM_NAME) return;
     try {
-        await bootReconciliationPromise;
+        await ensureBootReconciled();
         const ran = await runExclusivePollTick(async () => {
             const queue = await getQueue();
             // Different notebooks may be polled together. Only one can still be
@@ -1092,7 +1097,7 @@ const fallbackPdf = createPdfFallback({
 });
 
 async function resumePdfFallback(message) {
-    await bootReconciliationPromise;
+    await ensureBootReconciled();
     let file = null;
     if (message.fileDataBase64) file = decodeQueuedPdf(message.fileDataBase64, message.fileName);
     const payloadId = file ? crypto.randomUUID() : null;
@@ -1121,9 +1126,32 @@ async function resumePdfFallback(message) {
     return { ok: true, state: result.state };
 }
 
-const bootReconciliationPromise = reconcilePipelineRuntime()
-    .then(() => { kickQueue(); })
-    .catch(error => { console.error('[Recovery] Initial reconciliation failed:', error); throw error; });
+async function runBootReconciliation() {
+    try {
+        await reconcilePipelineRuntime();
+        kickQueue();
+        return true;
+    } catch (error) {
+        console.error('[Recovery] Initial reconciliation failed:', error);
+        return false;
+    }
+}
+
+let bootReconciliationPromise = runBootReconciliation();
+let bootRetryPromise = null;
+
+async function ensureBootReconciled() {
+    if (await bootReconciliationPromise) return;
+    const retry = bootRetryPromise || (bootRetryPromise = runBootReconciliation()
+        .then(succeeded => {
+            if (succeeded) bootReconciliationPromise = Promise.resolve(true);
+            return succeeded;
+        })
+        .finally(() => { bootRetryPromise = null; }));
+    if (!await retry) {
+        throw new Error('ScholarRelay could not restore its saved queue. Try again in a moment.');
+    }
+}
 
 // =========================================================================
 // Pipeline orchestration (steps 1-3: synchronous network calls)
@@ -1251,7 +1279,8 @@ function assertArtifactSelection(settings) {
 function decodeQueuedPdf(base64, filename) {
     assertPdfUploadSize(decodedBase64ByteLength(base64));
     if (!hasBase64PdfSignature(base64)) throw new Error('The selected file does not contain a PDF signature.');
-    const binary = atob(base64);
+    const payload = base64.includes(',') ? base64.slice(base64.indexOf(',') + 1) : base64;
+    const binary = atob(payload.replace(/\s+/g, ''));
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
     return { filename: filename || 'paper.pdf', fileData: bytes.buffer, mimeType: 'application/pdf' };
@@ -1263,7 +1292,7 @@ function assertQueuePdfBudget(queue, bytes) {
 }
 
 async function startPipelineRequest(message, uploadFile = null) {
-    await bootReconciliationPromise;
+    await ensureBootReconciled();
     const settings = { ...DEFAULT_SETTINGS, ...(message.settings || await getSettings()) };
     assertArtifactSelection(settings);
     let file = null;
@@ -1320,7 +1349,7 @@ async function startPipelineRequest(message, uploadFile = null) {
 }
 
 async function stopPipelineRequest(requestedRunId) {
-    await bootReconciliationPromise;
+    await ensureBootReconciled();
     const result = await pipelineState.transact(queue => {
         const job = queue.jobs.find(item => item.runId === requestedRunId);
         if (!job || !(job.status === 'queued' || job.step === 'queued_pdf' || canStopPipeline(job, requestedRunId))) return null;
@@ -1334,7 +1363,7 @@ async function stopPipelineRequest(requestedRunId) {
 }
 
 async function clearFinishedJobs() {
-    await bootReconciliationPromise;
+    await ensureBootReconciled();
     await pipelineState.transact(queue => {
         queue.jobs = queue.jobs.filter(isUnfinishedJob);
         return {};
@@ -1373,12 +1402,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
 
     if (message.type === 'GET_QUEUE') {
-        bootReconciliationPromise.then(getQueue).then(sendResponse)
+        ensureBootReconciled().then(getQueue).then(sendResponse)
             .catch(error => sendResponse({ error: error.message }));
         return true;
     }
     if (message.type === 'PAUSE_QUEUE') {
-        bootReconciliationPromise.then(() => pipelineState.transact(queue => {
+        ensureBootReconciled().then(() => pipelineState.transact(queue => {
             queue.paused = !!message.paused;
             return {};
         })).then(async () => { await syncQueueRuntime(); kickQueue(); sendResponse({ ok: true }); })
@@ -1386,12 +1415,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return true;
     }
     if (message.type === 'GET_STATE') {
-        bootReconciliationPromise.then(() => getState(message.runId)).then(sendResponse);
+        ensureBootReconciled().then(() => getState(message.runId)).then(sendResponse)
+            .catch(error => sendResponse({ ok: false, message: error?.message || 'Could not load pipeline state' }));
         return true;
     }
 
     if (message.type === 'LIST_COLLECTIONS') {
-        bootReconciliationPromise.then(() => listCollections())
+        ensureBootReconciled().then(() => listCollections())
             .then(collections => sendResponse({ ok: true, collections }))
             .catch(error => sendResponse({
                 ok: false,
@@ -1419,7 +1449,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             sendResponse({ ok: false, message: 'Detection was not associated with a browser tab.' });
             return false;
         }
-        chrome.storage.local.set({ detectedPdf }).then(() => sendResponse({ ok: true }));
+        chrome.storage.local.set({ detectedPdf }).then(() => sendResponse({ ok: true }))
+            .catch(error => sendResponse({ ok: false, message: error?.message || 'Could not save PDF detection' }));
         return true;
     }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "ScholarRelay",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "minimum_chrome_version": "120",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",

--- a/notebooklm-api.js
+++ b/notebooklm-api.js
@@ -407,7 +407,6 @@ function decodeResponse(rawResponse, rpcId, allowNull = false) {
 
 function extractFirstIdFromResult(result) {
   const MAX_DEPTH = 8;
-  const ID_PATTERN = /^[A-Za-z0-9_-]{10,}$/;
   const visited = new Set();
 
   function walk(node, depth = 0) {
@@ -429,7 +428,7 @@ function extractFirstIdFromResult(result) {
       const sourceMatch = value.match(/source\/([A-Za-z0-9_-]{10,})/i);
       if (sourceMatch) return sourceMatch[1];
 
-      if (ID_PATTERN.test(value)) return value;
+      if (isLikelyOpaqueId(value)) return value;
 
       if (value.startsWith('{') || value.startsWith('[')) {
         try {
@@ -446,8 +445,6 @@ function extractFirstIdFromResult(result) {
 
     if (typeof node === 'number') {
       const value = String(node);
-      if (ID_PATTERN.test(value)) return value;
-      if (value.length >= 10) return value;
       return null;
     }
 
@@ -478,6 +475,13 @@ function extractFirstIdFromResult(result) {
   }
 
   return walk(result, 0);
+}
+
+function isLikelyOpaqueId(value) {
+  if (!/^[A-Za-z0-9_-]{10,}$/.test(value) || /^\d+$/.test(value)) return false;
+  if (/^[a-z]+(?:_[a-z]+)*$/.test(value) || /^[A-Z]+(?:_[A-Z]+)*$/.test(value)) return false;
+  if (/^[A-Z][a-z]+$/.test(value)) return false;
+  return true;
 }
 
 // =========================================================================
@@ -1730,6 +1734,7 @@ async function listArtifactStatuses(notebookId) {
 
     let status;
     switch (statusCode) {
+      case ArtifactStatus.UNKNOWN: status = 'in_progress'; break;
       case ArtifactStatus.PROCESSING: status = 'in_progress'; break;
       case ArtifactStatus.PENDING: status = 'pending'; break;
       case ArtifactStatus.COMPLETED:
@@ -1849,6 +1854,7 @@ export const __testing = {
   artifactClientOptions,
   collectionRequestOptions,
   rpcCall,
+  extractFirstIdFromResult,
   resetTokens() {
     _csrfToken = null;
     _sessionId = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scholar-relay",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/background-lifecycle.test.js
+++ b/tests/background-lifecycle.test.js
@@ -18,7 +18,7 @@ import { withRequestDeadline } from '../request-deadline.js';
 const source = (await readFile(new URL('../background.js', import.meta.url), 'utf8'))
   .replace(/^import\s+[\s\S]*?from\s+'[^']+';\r?\n/gm, '');
 
-async function worker() {
+async function worker({ failInitialQueueRead = false } = {}) {
   const data = { pipelineState: { status: 'idle' }, userSettings: { chimeEnabled: false, notificationEnabled: false } };
   Object.defineProperty(data, 'pipelineState', {
     get: () => data.jobQueue?.jobs.at(-1) || { status: 'idle' },
@@ -28,7 +28,16 @@ async function worker() {
   const logs = [];
   const notifications = [];
   let listener;
+  let messageListener;
   const hooks = {};
+  if (failInitialQueueRead) {
+    hooks.read = key => {
+      if (key === 'jobQueue') {
+        hooks.read = null;
+        throw new Error('Temporary queue read failure');
+      }
+    };
+  }
   const noop = async () => {};
   const event = { addListener() {} };
   const apiMocks = Object.fromEntries(Object.entries(api).map(([key, value]) => [key,
@@ -46,7 +55,7 @@ async function worker() {
       } },
       alarms: { get: async () => null, clear: noop, create: noop, onAlarm: { addListener(fn) { listener = fn; } } },
       action: { setBadgeText: noop, setBadgeBackgroundColor: noop },
-      runtime: { onMessage: event },
+      runtime: { onMessage: { addListener(fn) { messageListener = fn; } } },
       notifications: { onClicked: event, onButtonClicked: event, onClosed: event,
         create: async (id, options) => notifications.push({ id, ...options }) },
       tabs: { create: noop },
@@ -55,8 +64,15 @@ async function worker() {
   vm.runInContext(source, context);
   await vm.runInContext('bootReconciliationPromise', context);
   await new Promise(resolve => setImmediate(resolve));
-  const functions = vm.runInContext('({startPipelineRequest, stopPipelineRequest, tickArtifactPoll, tickSourcePoll, resumePdfFallback, reconcilePipelineRuntime, getQueue})', context);
-  return { data, logs, notifications, hooks, context, listener, files, ...functions };
+  const functions = vm.runInContext('({startPipelineRequest, stopPipelineRequest, tickArtifactPoll, tickSourcePoll, resumePdfFallback, reconcilePipelineRuntime, getQueue, decodeQueuedPdf, shouldRetainJobPdf, ensureBootReconciled})', context);
+  return { data, logs, notifications, hooks, context, listener, messageListener, files, ...functions };
+}
+
+function sendWorkerMessage(workerState, message, sender = {}) {
+  return new Promise(resolve => {
+    const asyncResponse = workerState.messageListener(message, sender, resolve);
+    if (asyncResponse !== true) resolve(undefined);
+  });
 }
 
 test('completion and failure notifications use localized guidance without changing worker diagnostics', async () => {
@@ -328,6 +344,36 @@ test('queued PDFs are persisted before acknowledgment and removed with only thei
   assert.equal(w.files.size, 0);
   w.data.jobQueue.jobs.push({ ...running(), runId: 'large-saved-file', payloadBytes: jobs.MAX_QUEUED_PDF_BYTES });
   await assert.rejects(w.startPipelineRequest({}, file), /100 MiB/);
+});
+
+test('queued PDF data URLs decode correctly and payloads survive permission waits', async () => {
+  const w = await worker();
+  const raw = '%PDF-1.7\n durable fallback';
+  const decoded = w.decodeQueuedPdf(`data:application/pdf;base64,${btoa(raw)}`, 'fallback.pdf');
+  assert.equal(new TextDecoder().decode(decoded.fileData), raw);
+  assert.equal(w.shouldRetainJobPdf({ step: 'wait_pdf_access' }), true);
+  assert.equal(w.shouldRetainJobPdf({ step: 'wait_source' }), false);
+});
+
+test('boot reconciliation retries after a transient failure and message errors respond', async () => {
+  const w = await worker({ failInitialQueueRead: true });
+  assert.ok(w.logs.some(row => row[0] === 'error' && row[1].includes('Initial reconciliation failed')));
+  const recovered = await sendWorkerMessage(w, { type: 'GET_STATE', runId: 'missing' });
+  assert.equal(recovered.status, 'idle');
+
+  w.hooks.read = key => {
+    if (key === 'jobQueue') throw new Error('Queue unavailable');
+  };
+  const stateError = await sendWorkerMessage(w, { type: 'GET_STATE', runId: 'missing' });
+  assert.equal(stateError.ok, false);
+  assert.equal(stateError.message, 'Queue unavailable');
+  w.hooks.read = null;
+
+  w.hooks.write = () => { throw new Error('Storage unavailable'); };
+  const detectionError = await sendWorkerMessage(w, { type: 'DETECT_PDF', data: { pageUrl: 'https://example.org/paper.pdf' } },
+    { tab: { id: 7, url: 'https://example.org/paper.pdf' } });
+  assert.equal(detectionError.ok, false);
+  assert.equal(detectionError.message, 'Storage unavailable');
 });
 
 test('a paper awaiting PDF access does not block the next paper or let resume steal its slot', async () => {

--- a/tests/notebooklm-api.test.js
+++ b/tests/notebooklm-api.test.js
@@ -758,6 +758,25 @@ test('artifact status 1 is pending and status 2 is processing', async () => {
   assert.equal(processing.get('artifact-id-12345').status, 'in_progress');
 });
 
+test('unknown artifact status keeps polling and generic values are not IDs', async () => {
+  installFetch(url => {
+    if (url.endsWith('/')) return tokenResponse();
+    const artifact = Array(5).fill(null);
+    artifact[0] = 'artifact-id-12345';
+    artifact[2] = 1;
+    artifact[4] = 0;
+    return rpcResponse(__testing.RPCMethod.LIST_ARTIFACTS, [[artifact]]);
+  });
+
+  const statuses = await listArtifactStatuses('notebook-id-12345');
+  assert.equal(statuses.get('artifact-id-12345').status, 'in_progress');
+  for (const value of ['application', 'study_guide', 'PENDING_REVIEW', '1725000000000']) {
+    assert.equal(__testing.extractFirstIdFromResult(value), null);
+  }
+  assert.equal(__testing.extractFirstIdFromResult('artifact-id-12345'), 'artifact-id-12345');
+  assert.equal(__testing.extractFirstIdFromResult('AbCdEfGhIjKlMnOp'), 'AbCdEfGhIjKlMnOp');
+});
+
 test('notebook creation reads the ID field instead of a title or nested IDs', async () => {
   for (const wrap of [false, true]) {
     reset();


### PR DESCRIPTION
## Summary

- preserve queued PDF payloads while a job waits for site access and decode Data URL payloads correctly
- retry transient boot reconciliation failures and return errors to popup message callers
- keep unknown artifact states polling and reject generic words or timestamps as IDs
- bump the extension package to 1.4.1

## Validation

- `npm test` with 106 passing tests
- `npm run locales:check`
- `npm run smoke:chrome`, including seven locales and the 40 MiB restart transfer
- GitHub maintainer preflight with actionlint and Gitleaks
- `npm run package:store`

Closes #43
Closes #44
Closes #45
