### PR TITLE
Add inline queue progress and compact the no-PDF message

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -916,5 +916,17 @@
   "ui_19f575ce": {
     "message": "Verbindung versuchen",
     "description": "Try connection"
+  },
+  "ui_244aa556": {
+    "message": "$1/$2 fertig",
+    "description": "$1/$2 ready"
+  },
+  "ui_b78d0565": {
+    "message": "Wartezeit",
+    "description": "Time queued"
+  },
+  "ui_faff56b8": {
+    "message": "Verstrichene Zeit",
+    "description": "Elapsed time"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -916,5 +916,17 @@
   "ui_19f575ce": {
     "message": "Try connection",
     "description": "Try connection"
+  },
+  "ui_244aa556": {
+    "message": "$1/$2 ready",
+    "description": "$1/$2 ready"
+  },
+  "ui_b78d0565": {
+    "message": "Time queued",
+    "description": "Time queued"
+  },
+  "ui_faff56b8": {
+    "message": "Elapsed time",
+    "description": "Elapsed time"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -916,5 +916,17 @@
   "ui_19f575ce": {
     "message": "Intentar conexión",
     "description": "Try connection"
+  },
+  "ui_244aa556": {
+    "message": "$1/$2 listos",
+    "description": "$1/$2 ready"
+  },
+  "ui_b78d0565": {
+    "message": "Tiempo en cola",
+    "description": "Time queued"
+  },
+  "ui_faff56b8": {
+    "message": "Tiempo transcurrido",
+    "description": "Elapsed time"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -916,5 +916,17 @@
   "ui_19f575ce": {
     "message": "Réessayer la connexion",
     "description": "Try connection"
+  },
+  "ui_244aa556": {
+    "message": "$1/$2 prêts",
+    "description": "$1/$2 ready"
+  },
+  "ui_b78d0565": {
+    "message": "Temps en file",
+    "description": "Time queued"
+  },
+  "ui_faff56b8": {
+    "message": "Temps écoulé",
+    "description": "Elapsed time"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -916,5 +916,17 @@
   "ui_19f575ce": {
     "message": "再接続",
     "description": "Try connection"
+  },
+  "ui_244aa556": {
+    "message": "$1/$2 完了",
+    "description": "$1/$2 ready"
+  },
+  "ui_b78d0565": {
+    "message": "待機時間",
+    "description": "Time queued"
+  },
+  "ui_faff56b8": {
+    "message": "経過時間",
+    "description": "Elapsed time"
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -916,5 +916,17 @@
   "ui_19f575ce": {
     "message": "다시 연결",
     "description": "Try connection"
+  },
+  "ui_244aa556": {
+    "message": "$1/$2개 완료",
+    "description": "$1/$2 ready"
+  },
+  "ui_b78d0565": {
+    "message": "대기 시간",
+    "description": "Time queued"
+  },
+  "ui_faff56b8": {
+    "message": "경과 시간",
+    "description": "Elapsed time"
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -916,5 +916,17 @@
   "ui_19f575ce": {
     "message": "Tentar conexão",
     "description": "Try connection"
+  },
+  "ui_244aa556": {
+    "message": "$1/$2 prontos",
+    "description": "$1/$2 ready"
+  },
+  "ui_b78d0565": {
+    "message": "Tempo na fila",
+    "description": "Time queued"
+  },
+  "ui_faff56b8": {
+    "message": "Tempo decorrido",
+    "description": "Elapsed time"
   }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -429,3 +429,13 @@ English: Keep queued papers and PDFs during a connection outage instead of faili
 한국어: 연결 장애가 발생해도 대기 중인 논문과 PDF를 실패 처리하지 않고 보관합니다. 사용자가 연결을 다시 시도할 수 있습니다. 오류 알림에서 해당 논문의 상세 화면을 열며 실패한 단계와 부분 완료 결과를 유지합니다.
 
 No existing release package or store submission is changed. Regression coverage includes persisted holds, worker restart, PDF bytes, stale resume, independent pause, ongoing monitoring, no mutation replay and safe notification routing. Browser checks cover the job link, failed-stage display and connection action.
+
+### September 8 compact queue progress
+
+Issues #56 and #57 reuse the queue's phase row for a small activity indicator, confirmed artifact counts and elapsed time. The clock uses saved timestamps and freezes terminal jobs at completion. Only its text changes on local timer ticks, leaving card markup, focus, expanded history and network polling unchanged. Counts appear after artifact submission is settled rather than treating the partial submission list as the final total. Reduced motion disables both queue rotation and the existing active-step pulse.
+
+English: See elapsed time and completed artifact counts without adding height to the queue cards. The no-PDF message no longer has a decorative file icon or excessive padding. Both page import and local upload remain available.
+
+한국어: 대기열 카드의 높이를 늘리지 않고 경과 시간과 완료된 아티팩트 수를 표시합니다. PDF 미감지 안내의 장식용 파일 아이콘과 과도한 여백을 제거했습니다. 웹페이지 가져오기와 로컬 PDF 업로드는 그대로 사용할 수 있습니다.
+
+All seven UI catalogs are updated. Deterministic checks cover timestamps, stopped and completed jobs, partial submission and activity state. Browser checks cover seven-language layouts, live text updates, stable card height and focus, expanded history, reduced motion and both no-PDF actions. Existing release versions and submitted packages are unchanged.

--- a/docs/localization/messages.json
+++ b/docs/localization/messages.json
@@ -226,5 +226,8 @@
   "Could not recognize the Gemini Notebook session. Open Gemini Notebook and check the details.": ["Gemini Notebook 세션을 인식하지 못했습니다. Gemini Notebook을 열고 상세 내용을 확인하세요.", "Gemini Notebook のセッションを認識できませんでした。Gemini Notebook を開いて詳細を確認してください。", "No se pudo reconocer la sesión de Gemini Notebook. Abre Gemini Notebook y consulta los detalles.", "La session Gemini Notebook n’a pas été reconnue. Ouvrez Gemini Notebook et consultez les détails.", "Die Gemini Notebook-Sitzung wurde nicht erkannt. Öffnen Sie Gemini Notebook und prüfen Sie die Details.", "Não foi possível reconhecer a sessão do Gemini Notebook. Abra o Gemini Notebook e confira os detalhes."],
   "Waiting for connection. Your paper is saved.": ["연결을 기다리고 있습니다. 논문은 저장되어 있습니다.", "接続を待っています。論文は保存されています。", "Esperando conexión. Tu artículo está guardado.", "En attente de connexion. Votre article est enregistré.", "Warten auf Verbindung. Ihr Artikel ist gespeichert.", "Aguardando conexão. Seu artigo está salvo."],
   "Connection needed": ["연결 필요", "接続が必要", "Se necesita conexión", "Connexion nécessaire", "Verbindung erforderlich", "Conexão necessária"],
-  "Try connection": ["다시 연결", "再接続", "Intentar conexión", "Réessayer la connexion", "Verbindung versuchen", "Tentar conexão"]
+  "Try connection": ["다시 연결", "再接続", "Intentar conexión", "Réessayer la connexion", "Verbindung versuchen", "Tentar conexão"],
+  "$1/$2 ready": ["$1/$2개 완료", "$1/$2 完了", "$1/$2 listos", "$1/$2 prêts", "$1/$2 fertig", "$1/$2 prontos"],
+  "Time queued": ["대기 시간", "待機時間", "Tiempo en cola", "Temps en file", "Wartezeit", "Tempo na fila"],
+  "Elapsed time": ["경과 시간", "経過時間", "Tiempo transcurrido", "Temps écoulé", "Verstrichene Zeit", "Tempo decorrido"]
 }

--- a/job-queue.js
+++ b/job-queue.js
@@ -22,6 +22,27 @@ export function jobHandoff(job) {
     return 'preparing';
 }
 
+// Presentation helpers read persisted timestamps. They never poll or write state.
+export function jobElapsedText(job, now = Date.now()) {
+    const start = Date.parse(job.status === 'queued' ? job.queuedAt : job.startedAt || job.queuedAt);
+    const end = isUnfinishedJob(job) ? now : Date.parse(job.completedAt);
+    if (!Number.isFinite(start) || !Number.isFinite(end)) return '';
+    const seconds = Math.floor(Math.max(0, end - start) / 1000);
+    const pad = value => String(value).padStart(2, '0');
+    if (seconds < 3600) return `${pad(Math.floor(seconds / 60))}:${pad(seconds % 60)}`;
+    return `${Math.floor(seconds / 3600)}:${pad(Math.floor(seconds / 60) % 60)}:${pad(seconds % 60)}`;
+}
+
+export function jobReadyCount(job) {
+    // During submission, tasks contains only requests attempted so far.
+    if (!['wait_artifacts', 'done'].includes(job.failedStep || job.step) || !job.tasks?.length) return null;
+    return { ready: job.tasks.filter(task => task.status === 'completed').length, total: job.tasks.length };
+}
+
+export function hasJobActivity(job) {
+    return job.status === 'running' && !['wait_pdf_access', 'queued_pdf'].includes(job.step);
+}
+
 // One serialized writer for the whole queue. A late callback may update only
 // its own running job, with the same step checks used by the original pipeline.
 export function createJobQueue({ read, write }) {

--- a/popup.html
+++ b/popup.html
@@ -117,17 +117,11 @@
     }
 
     .no-pdf {
-      text-align: center;
-      padding: 24px 16px;
+      text-align: left;
+      padding: 6px 0;
       color: var(--text-dim);
-      font-size: 13px;
-      line-height: 1.5;
-    }
-
-    .no-pdf .icon {
-      font-size: 32px;
-      margin-bottom: 8px;
-      opacity: 0.5;
+      font-size: 12px;
+      line-height: 1.4;
     }
 
     /* ---- Notebook title bar ---- */
@@ -733,6 +727,16 @@
     .job-title { display: block; width: 100%; font-size: 12px; font-weight: 600; overflow-wrap: anywhere; }
     .job-title:hover { text-decoration: underline; }
     .job-phase { font-size: 11px; font-weight: 600; color: var(--text-dim); margin-top: 4px; }
+    .job-phase { display: flex; align-items: center; gap: 5px; white-space: nowrap; }
+    .job-phase-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+    .job-ready-count { flex: 0 0 auto; }
+    .job-elapsed { flex: 0 0 auto; min-width: 8ch; margin-left: auto; text-align: right; font-variant-numeric: tabular-nums; }
+    .job-activity { width: 8px; height: 8px; flex: 0 0 8px; border: 1px solid currentColor; border-radius: 50%; }
+    .job-activity.is-active { border-top-color: transparent; animation: job-spin 0.9s linear infinite; }
+    @keyframes job-spin { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) {
+      .job-activity.is-active, .step-indicator.active { animation: none; }
+    }
     .job-hint { margin: 5px 0 8px; font-size: 11px; line-height: 1.4; overflow-wrap: anywhere; color: var(--text-dim); }
     .handoff-note { font-size: 12px; line-height: 1.5; padding: 9px; margin: 8px 0; background: var(--surface-alt); border-radius: 5px; }
     #finished-jobs { font-size: 12px; margin-top: 8px; }

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,4 @@
-import { jobHandoff, isUnfinishedJob } from './job-queue.js';
+import { jobHandoff, isUnfinishedJob, jobElapsedText, jobReadyCount, hasJobActivity } from './job-queue.js';
 import { DEFAULT_SETTINGS as DEFAULTS } from './settings.js';
 import { t, localizeStaticDocument, progressDetail, errorSummary, artifactLabel, artifactStatusLabel } from './i18n.js';
 import { inspectPaperPage } from './content.js';
@@ -48,6 +48,29 @@ function queuePhase(job) {
     return job.step === 'wait_artifacts' ? t('Generating') : t('Preparing');
 }
 
+function queueStatusHtml(job) {
+    const count = jobReadyCount(job);
+    const activity = hasJobActivity(job) ? ' is-active' : '';
+    const phase = queuePhase(job);
+    const countText = count ? t('$1/$2 ready', [count.ready, count.total]) : '';
+    const clockLabel = job.status === 'queued' ? t('Time queued') : t('Elapsed time');
+    // Clock content is deliberately excluded from the HTML comparison below.
+    return '<div class="job-phase"><span class="job-activity' + activity + '" aria-hidden="true"></span>' +
+        '<span class="job-phase-label" title="' + escapeHtml(phase) + '">' + escapeHtml(phase) + '</span>' +
+        (count ? '<span class="job-ready-count">' + escapeHtml(countText) + '</span>' : '') +
+        '<span class="job-elapsed" data-elapsed="' + escapeHtml(job.runId) + '" title="' + escapeHtml(clockLabel) + '" role="timer" aria-live="off"></span></div>';
+}
+
+function updateElapsedTimes() {
+    const jobs = new Map(queueSnapshot.jobs.map(job => [job.runId, job]));
+    const now = Date.now();
+    for (const element of queueEl.querySelectorAll('[data-elapsed]')) {
+        const job = jobs.get(element.dataset.elapsed);
+        const text = job ? jobElapsedText(job, now) : '';
+        if (element.textContent !== text) element.textContent = text;
+    }
+}
+
 async function refreshQueue() {
     const queue = await chrome.runtime.sendMessage({ type: 'GET_QUEUE' });
     if (!Array.isArray(queue?.jobs)) throw new Error(queue?.error || 'Could not read the saved queue.');
@@ -59,7 +82,7 @@ async function refreshQueue() {
             ['wait_source','wait_artifacts','wait_pdf_access','download_pdf','queued_pdf'].includes(job.step));
         return '<article class="job-card" data-job="' + escapeHtml(job.runId) + '">' +
             '<button class="job-title" data-show="' + escapeHtml(job.runId) + '">' + escapeHtml(job.sourceTitle || job.notebookTitle || job.pdfUrl || t('Source')) + '</button>' +
-            '<div class="job-phase">' + escapeHtml(queuePhase(job)) + '</div>' +
+            queueStatusHtml(job) +
             '<p class="job-hint">' + escapeHtml(handoffMessage(job)) + '</p>' +
             '<div class="job-actions">' + (job.notebookUrl ? '<a href="' + escapeHtml(job.notebookUrl) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(t('Open Notebook')) + '</a>' : '') +
             (canStop ? '<button data-stop="' + escapeHtml(job.runId) + '">' + escapeHtml(job.status === 'queued' || job.step === 'queued_pdf' ? t('Remove from queue') : t('Stop this job')) + '</button>' : '') + '</div></article>';
@@ -109,6 +132,7 @@ async function refreshQueue() {
             } catch (error) { showError(error.message); }
         });
     }
+    updateElapsedTimes();
     const selected = queue.jobs.find(job => job.runId === selectedRunId);
     if (selected) renderProgress(selected);
     return queue;
@@ -555,8 +579,7 @@ function renderNoPdf() {
     delete contentEl.dataset.renderMode;
     contentEl.innerHTML = `
     <div class="no-pdf">
-      <div class="icon">📄</div>
-      ${escapeHtml(t("No PDF detected on this page."))}<br>
+      ${escapeHtml(t("No PDF detected on this page."))}
       <span style="font-size:11px; color:var(--text-dim)">${escapeHtml(t("You can still try importing this page URL directly."))}</span>
     </div>
     <button class="btn-generate" id="btn-start-url">${escapeHtml(t('Add page to queue'))}</button>
@@ -1141,10 +1164,12 @@ function readFileAsBase64(file) {
 let pollInterval = null;
 let pollInFlight = false;
 let pollingEnabled = false;
+let elapsedTimer = null;
 
 function startPolling() {
     if (pollingEnabled) return;
     pollingEnabled = true;
+    elapsedTimer = setInterval(updateElapsedTimes, 1000);
     const tick = async () => {
         if (!pollingEnabled || pollInFlight) return;
         pollInFlight = true;
@@ -1166,6 +1191,8 @@ function startPolling() {
 
 function stopPolling() {
     pollingEnabled = false;
+    clearInterval(elapsedTimer);
+    elapsedTimer = null;
     if (pollInterval) {
         clearTimeout(pollInterval);
     }

--- a/scripts/review-smoke.mjs
+++ b/scripts/review-smoke.mjs
@@ -38,3 +38,70 @@ export async function recoverySmoke({ popup, evaluate, reload, completedState })
     assert(!queue.serviceBlock && queue.paused && queue.jobs[0].status === 'queued', 'Connection resume changed the user pause or started work');
     console.log('Recovery popup smoke passed: job deep link, failed stage, connection hold and independent pause');
 }
+
+export async function compactProgressSmoke({ popup, evaluate, reload, root, origin }) {
+    const { readFile } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const { messageKey } = await import('../i18n.js');
+    const assert = (condition, message) => { if (!condition) throw new Error(message); };
+    const fixedNow = Date.now();
+    const started = new Date(fixedNow - 65000).toISOString();
+    const tasks = [{ type: 'audio', status: 'completed' }, { type: 'video', status: 'in_progress' }];
+    const jobs = [
+        { runId: 'clock-queued', sourceTitle: 'Queued paper', status: 'queued', step: 'queued', queuedAt: started },
+        { runId: 'clock-running', sourceTitle: 'Generating paper', status: 'running', step: 'wait_artifacts', startedAt: started,
+            stepStartedAt: new Date(fixedNow).toISOString(), tasks, settings: { notificationEnabled: false } },
+        { runId: 'clock-stopped', sourceTitle: 'Stopped paper', status: 'stopped', step: 'wait_artifacts', startedAt: started,
+            completedAt: new Date(fixedNow - 5000).toISOString(), tasks },
+    ];
+    await evaluate(popup, `chrome.tabs.create({url:${JSON.stringify(origin + '/plain')},active:true})`);
+    for (const locale of ['en', 'ko', 'ja', 'es', 'fr', 'de', 'pt_BR']) {
+        const catalog = JSON.parse(await readFile(join(root, '_locales', locale, 'messages.json'), 'utf8'));
+        const countText = catalog[messageKey('$1/$2 ready')].message.replace('$1', '1').replace('$2', '2');
+        const { identifier } = await popup.call('Page.addScriptToEvaluateOnNewDocument', { source: `
+            const catalog=${JSON.stringify(catalog)};
+            chrome.i18n.getUILanguage=()=>${JSON.stringify(locale.replace('_', '-'))};
+            chrome.i18n.getMessage=(key, values=[])=>catalog[key]?.message.replace(/\\$(\\d+)/g,(_,i)=>values[i-1]??'')||'';
+            globalThis.__clockNow=${fixedNow}; Date.now=()=>globalThis.__clockNow;
+        ` });
+        try {
+            await evaluate(popup, `chrome.storage.local.set({jobQueue:${JSON.stringify({ version: 1, paused: true, jobs })}})`);
+            await reload(popup);
+            const view = await evaluate(popup, `(() => {
+                document.getElementById('finished-jobs').open=true;
+                const phases=[...document.querySelectorAll('.job-phase')];
+                return {width:document.documentElement.scrollWidth,noPdfHeight:document.querySelector('.no-pdf')?.getBoundingClientRect().height,
+                    icon:!!document.querySelector('.no-pdf .icon'),actions:!!document.getElementById('btn-start-url')&&!!document.getElementById('btn-upload-manual'),
+                    count:document.querySelector('[data-job="clock-running"] .job-ready-count')?.textContent,
+                    clocks:[...document.querySelectorAll('[data-elapsed]')].map(el=>el.textContent),
+                    phasesFit:phases.every(el=>el.scrollWidth<=el.clientWidth+1 && el.getBoundingClientRect().height<20),
+                    active:[...document.querySelectorAll('.job-activity.is-active')].map(el=>el.closest('[data-job]').dataset.job)};
+            })()`);
+            assert(view.width <= 360 && view.phasesFit, `${locale} compact phase overflow`);
+            assert(view.noPdfHeight > 0 && view.noPdfHeight < 85 && !view.icon && view.actions, `${locale} no-PDF state is not compact or lost its actions`);
+            assert(view.count === countText, `${locale} artifact count not localized`);
+            assert(JSON.stringify(view.clocks) === JSON.stringify(['01:05', '01:05', '01:00']), `${locale} persisted clocks are wrong`);
+            assert(JSON.stringify(view.active) === JSON.stringify(['clock-running']), `${locale} inactive job animation`);
+            if (locale === 'en') {
+                await evaluate(popup, `(() => {
+                    globalThis.__clockNode=document.querySelector('[data-elapsed="clock-queued"]');
+                    globalThis.__clockButton=document.querySelector('[data-show="clock-queued"]'); __clockButton.focus();
+                    globalThis.__clockHeight=__clockNode.closest('.job-card').getBoundingClientRect().height;
+                    globalThis.__clockNow+=2000;
+                })()`);
+                await new Promise(resolve => setTimeout(resolve, 2200));
+                assert(await evaluate(popup, `__clockNode===document.querySelector('[data-elapsed="clock-queued"]') &&
+                    __clockNode.textContent==='01:07' && document.activeElement===__clockButton &&
+                    __clockNode.closest('.job-card').getBoundingClientRect().height===__clockHeight &&
+                    document.getElementById('finished-jobs').open && document.querySelector('[data-elapsed="clock-stopped"]').textContent==='01:00' &&
+                    __clockNode.getAttribute('aria-live')==='off'`), 'Timer tick rebuilt markup, lost focus or expanded history, changed height, or advanced a stopped clock');
+                await popup.call('Emulation.setEmulatedMedia', { features: [{ name: 'prefers-reduced-motion', value: 'reduce' }] });
+                assert(await evaluate(popup, `getComputedStyle(document.querySelector('.job-activity.is-active')).animationName==='none'`), 'Reduced motion still animates');
+                await popup.call('Emulation.setEmulatedMedia', { features: [] });
+            }
+        } finally { await popup.call('Page.removeScriptToEvaluateOnNewDocument', { identifier }); }
+    }
+    await evaluate(popup, `globalThis.__smoke.setFixtureState({status:'idle'})`);
+    await reload(popup);
+    console.log('Compact progress smoke passed in seven locales: timers, counts, stable focus and height, reduced motion and no-PDF actions');
+}

--- a/scripts/smoke-extension.mjs
+++ b/scripts/smoke-extension.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { localizationSmoke } from './localization-smoke.mjs';
-import { recoverySmoke } from './review-smoke.mjs';
+import { recoverySmoke, compactProgressSmoke } from './review-smoke.mjs';
 
 const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const tempRoot = await mkdtemp(join(tmpdir(), 'scholar-relay-smoke-'));
@@ -447,6 +447,7 @@ try {
 
   await localizationSmoke({ popup, evaluate, reload, root: sourceRoot, completedState });
   await recoverySmoke({ popup, evaluate, reload, completedState });
+  await compactProgressSmoke({ popup, evaluate, reload, root: sourceRoot, origin });
 
   // Exercise the real Chrome message bridge and the complete file upload client.
   await evaluate(popup, `globalThis.__smoke.setFixtureState({status:'idle'})`);

--- a/tests/queue-progress.test.js
+++ b/tests/queue-progress.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { jobElapsedText, jobReadyCount, hasJobActivity } from '../job-queue.js';
+
+const start = '2026-09-08T00:00:00Z';
+const now = Date.parse(start) + 125000;
+
+test('queued and running clocks use their persisted timestamps after reopening', () => {
+  assert.equal(jobElapsedText({ status: 'queued', queuedAt: start }, now), '02:05');
+  assert.equal(jobElapsedText({ status: 'running', startedAt: start }, now), '02:05');
+  assert.equal(jobElapsedText({ status: 'running', startedAt: start }, now + 3600000), '1:02:05');
+  assert.equal(jobElapsedText({ status: 'running', startedAt: start }, now + 86400000), '24:02:05');
+});
+
+test('terminal clocks freeze, including a queued job removed before it started', () => {
+  for (const status of ['completed', 'error', 'stopped']) {
+    const job = { status, startedAt: start, completedAt: new Date(now).toISOString() };
+    assert.equal(jobElapsedText(job, now + 10000), '02:05');
+    assert.equal(jobElapsedText(job, now + 999999), '02:05');
+  }
+  assert.equal(jobElapsedText({ status: 'stopped', queuedAt: start, completedAt: new Date(now).toISOString() }), '02:05');
+});
+
+test('missing or invalid timestamps do not fabricate elapsed time; clock skew clamps to zero', () => {
+  assert.equal(jobElapsedText({ status: 'running' }, now), '');
+  assert.equal(jobElapsedText({ status: 'stopped', startedAt: start }, now), '');
+  assert.equal(jobElapsedText({ status: 'running', startedAt: 'invalid' }, now), '');
+  assert.equal(jobElapsedText({ status: 'queued', queuedAt: start }, Date.parse(start) - 1000), '00:00');
+});
+
+test('artifact counts are shown only after the submission list is settled', () => {
+  const tasks = [{ status: 'completed' }, { status: 'failed' }, { status: 'uncertain' }];
+  assert.equal(jobReadyCount({ step: 'generate_artifacts', tasks }), null);
+  assert.equal(jobReadyCount({ step: 'error', failedStep: 'generate_artifacts', tasks }), null);
+  assert.deepEqual(jobReadyCount({ step: 'wait_artifacts', tasks }), { ready: 1, total: 3 });
+  assert.deepEqual(jobReadyCount({ step: 'error', failedStep: 'wait_artifacts', tasks }), { ready: 1, total: 3 });
+  assert.equal(jobReadyCount({ step: 'done', tasks: [] }), null);
+});
+
+test('only active work animates, not queued, stopped or permission-wait jobs', () => {
+  for (const status of ['queued', 'stopped', 'error', 'completed']) {
+    assert.equal(hasJobActivity({ status, step: 'wait_artifacts' }), false);
+  }
+  for (const step of ['queued_pdf', 'wait_pdf_access']) assert.equal(hasJobActivity({ status: 'running', step }), false);
+  assert.equal(hasJobActivity({ status: 'running', step: 'wait_artifacts' }), true);
+});


### PR DESCRIPTION
## Changes

Stacked on #59. Reuse the existing phase row for a small spinner, completed-artifact counts and right-aligned elapsed time. Derive clocks from saved timestamps, freeze finished/stopped jobs, and update only clock text. Do not rebuild cards, announce every second, increase remote polling or invent a percentage/ETA. Counts remain hidden until the artifact submission list is settled.

Remove the no-PDF file icon, forced line break and excessive padding. Keep both page import and local PDF upload. Update all seven locales and respect reduced motion.

## Validation

138 deterministic tests pass locally and on the branch preparation runner. Five new tests cover queued/running/terminal clocks, invalid timestamps, partial submission counts and activity states. New Chrome smoke covers seven-language compact rows, no-PDF height/actions, timer node identity, keyboard focus, expanded history, stable card height and reduced motion. Locale and whitespace checks pass. Exact-head Chrome smoke and packaging are exercised by PR CI.

No version, permissions, release assets or Chrome Web Store submission changes.

Review/merge order is #58, then #59, then this PR. Retarget dependent PRs to main after their prerequisite merges.

Closes #56
Closes #57