### PR TITLE
Prepare v1.4.3 session and queue recovery release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ ScholarRelay(Scholar Relay)는 PDF, arXiv 연구 논문, 웹페이지를 Gemini 
 
 v1.3.2에서는 화면과 알림을 영어, 한국어, 일본어, 스페인어, 프랑스어, 독일어, 브라질 포르투갈어로 제공합니다. 화면 언어는 Chrome 설정을 따르며 지원하지 않는 언어에서는 영어를 사용합니다. 아티팩트 생성 언어는 별도 설정이며 기존 선택값은 유지됩니다. 기술 진단은 상세 내용에 원문으로 표시됩니다.
 
+1.4.3은 세션 연결 장애가 발생하면 시작 전 논문과 PDF를 보존하고 재연결을 기다립니다. 오류 알림에서 해당 작업을 열 수 있으며 대기열에 경과 시간과 완료 개수를 표시합니다.
+
 ### 주요 기능
 
 - 현재 탭에서 PDF, arXiv 논문, 웹페이지를 감지해 Gemini Notebook 소스로 추가합니다.
@@ -172,3 +174,7 @@ The consumer Gemini Notebook web application does not provide an official public
 ## License
 
 MIT. See [LICENSE](./LICENSE).
+
+### Version 1.4.3
+
+Session discovery failures hold unstarted papers and saved PDFs until you reconnect. Error notifications open the affected job. Compact queue rows show elapsed time and completed artifact counts.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -439,3 +439,19 @@ English: See elapsed time and completed artifact counts without adding height to
 한국어: 대기열 카드의 높이를 늘리지 않고 경과 시간과 완료된 아티팩트 수를 표시합니다. PDF 미감지 안내의 장식용 파일 아이콘과 과도한 여백을 제거했습니다. 웹페이지 가져오기와 로컬 PDF 업로드는 그대로 사용할 수 있습니다.
 
 All seven UI catalogs are updated. Deterministic checks cover timestamps, stopped and completed jobs, partial submission and activity state. Browser checks cover seven-language layouts, live text updates, stable card height and focus, expanded history, reduced motion and both no-PDF actions. Existing release versions and submitted packages are unchanged.
+
+### v1.4.2 publication and API submission
+
+On September 8, 2026, the public listing and authenticated API confirmed v1.4.1 was published. PR #51 checks passed at a0a4e06408d21548ecaecc9d230fbdda85533321, and merged-main CI passed at a9ecdac489d3bd633dea090b026290dc5658fdf2 in run 34045282596. The release was built from a separate clean checkout at that commit, preserving unrelated local changes.
+
+[GitHub v1.4.2](https://github.com/mahlernim/scholar-relay/releases/tag/v1.4.2) was published with equivalent English and Korean notes. The canonical ZIP contains 30 allowlisted runtime files, embeds version 1.4.2, and is 127,696 bytes. Every decompressed file matches the release checkout. The downloaded GitHub ZIP matches the original and passes ZIP integrity verification. SHA-256 is `5f42ed67302c0e5928873b34599233cde629d31a6389d369022a4ba307288655`.
+
+The shared google-store-publisher CLI validated the artifact and produced a dry-run plan with warning blocking enabled, normal review, and automatic publication after approval. The same ZIP was submitted to existing item `epopghhfmpokhbalmnfcopmplffphdbb`. Upload returned `SUCCEEDED`, and both submission reconciliation and an independent status read returned submitted version 1.4.2 `PENDING_REVIEW`. Published remained 1.4.1. Pending review is not public availability.
+
+A dedicated Chrome Web Store service account was linked with explicit authorization. Local operator authentication uses short-lived impersonated tokens without a downloaded service-account key. The local runbook and fixed-target wrapper are at `%USERPROFILE%/.config/store-publisher/README.md` and `scholar-relay.ps1`. The wrapper invokes the shared CLI and works around its Windows gcloud launch failure. Status is read-only, submit defaults to a dry run, and execution requires the Execute switch. Do not replay uncertain submissions or cancel active review without authorization. No recurring monitor was created.
+
+The separately reported sign-in detection failure has not been confirmed fixed by v1.4.2. Concurrent token-request sharing should not be presented as proof that this reported problem is resolved.
+
+### v1.4.3 expedited release
+
+PRs #58, #59 and #60 merged in dependency order after their exact-head checks passed. Version 1.4.3 replaces the pending 1.4.2 submission with session discovery classification, fully shared token refreshes, durable connection holds, actionable error notifications and compact progress. The existing remote-mutation uncertainty safeguards remain unchanged. The original signed-in incident is not claimed to be reproduced or fully resolved.

--- a/docs/releases/v1.4.3.md
+++ b/docs/releases/v1.4.3.md
@@ -1,0 +1,21 @@
+## English
+
+- Distinguish session, network, rate-limit and compatibility errors instead of always asking you to sign in.
+- Share all overlapping authentication refreshes.
+- Preserve unstarted papers and saved PDFs during connection failures, with an explicit reconnect action.
+- Open the affected job from error notifications and retain the failed stage and partial results.
+- Show elapsed time and completed artifact counts in compact queue rows, and simplify the no-PDF message.
+
+The originally reported signed-in incident has not been reproduced against a live Google session. This release fixes the confirmed error classification and queue recovery defects without replaying uncertain remote operations.
+
+## 한국어
+
+- 세션, 네트워크, 요청 제한, 호환성 오류를 구분하여 무조건 로그인을 요구하지 않습니다.
+- 동시에 발생하는 모든 인증 갱신 요청을 공유합니다.
+- 연결 장애 시 시작 전 논문과 저장된 PDF를 보존하고 명시적인 재연결 동작을 제공합니다.
+- 오류 알림에서 해당 작업을 열고 실패 단계와 부분 결과를 보존합니다.
+- 간결한 대기열 행에 경과 시간과 완료 개수를 표시하고 PDF 미감지 안내를 정리했습니다.
+
+최초 보고된 로그인 상태의 문제는 실제 Google 세션에서 재현하지 못했습니다. 이번 릴리스는 확인된 오류 분류와 대기열 복구 결함을 수정하며 결과가 불확실한 원격 작업을 다시 실행하지 않습니다.
+
+Closes #52, #53, #54, #55, #56 and #57 through PRs #58, #59 and #60.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "ScholarRelay",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "minimum_chrome_version": "120",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scholar-relay",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bump manifest and package versions to 1.4.3 after #58, #59 and #60. Add equivalent Korean and English release notes and record the prior submission. Validation includes 138 passing tests, seven locale catalogs and local preflight. Closing issues #52 through #57 are linked by the merged implementation PRs.