### PR TITLE
Show generation limits on affected jobs

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -928,5 +928,9 @@
   "ui_faff56b8": {
     "message": "Verstrichene Zeit",
     "description": "Elapsed time"
+  },
+  "ui_c6bbc618": {
+    "message": "Die Erstellung von $1 ist eingeschränkt. Versuche es später im vorhandenen Notebook erneut.",
+    "description": "Generation is limited for $1. Try again later in the existing notebook."
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -928,5 +928,9 @@
   "ui_faff56b8": {
     "message": "Elapsed time",
     "description": "Elapsed time"
+  },
+  "ui_c6bbc618": {
+    "message": "Generation is limited for $1. Try again later in the existing notebook.",
+    "description": "Generation is limited for $1. Try again later in the existing notebook."
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -928,5 +928,9 @@
   "ui_faff56b8": {
     "message": "Tiempo transcurrido",
     "description": "Elapsed time"
+  },
+  "ui_c6bbc618": {
+    "message": "La generación de $1 está limitada. Inténtalo más tarde en el cuaderno existente.",
+    "description": "Generation is limited for $1. Try again later in the existing notebook."
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -928,5 +928,9 @@
   "ui_faff56b8": {
     "message": "Temps écoulé",
     "description": "Elapsed time"
+  },
+  "ui_c6bbc618": {
+    "message": "La génération de $1 est limitée. Réessayez plus tard dans le notebook existant.",
+    "description": "Generation is limited for $1. Try again later in the existing notebook."
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -928,5 +928,9 @@
   "ui_faff56b8": {
     "message": "経過時間",
     "description": "Elapsed time"
+  },
+  "ui_c6bbc618": {
+    "message": "$1 の生成が制限されています。後で既存のノートブックで再試行してください。",
+    "description": "Generation is limited for $1. Try again later in the existing notebook."
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -928,5 +928,9 @@
   "ui_faff56b8": {
     "message": "경과 시간",
     "description": "Elapsed time"
+  },
+  "ui_c6bbc618": {
+    "message": "$1 생성이 제한되었습니다. 나중에 기존 노트북에서 다시 시도하세요.",
+    "description": "Generation is limited for $1. Try again later in the existing notebook."
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -928,5 +928,9 @@
   "ui_faff56b8": {
     "message": "Tempo decorrido",
     "description": "Elapsed time"
+  },
+  "ui_c6bbc618": {
+    "message": "A geração de $1 está limitada. Tente novamente mais tarde no notebook existente.",
+    "description": "Generation is limited for $1. Try again later in the existing notebook."
   }
 }

--- a/background.js
+++ b/background.js
@@ -24,7 +24,7 @@ import { withRequestDeadline } from './request-deadline.js';
 import { DEFAULT_SETTINGS } from './settings.js';
 import { createJobQueue, canStartNextJob, isUnfinishedJob, MAX_QUEUED_JOBS, MAX_QUEUED_PDF_BYTES } from './job-queue.js';
 import { createQueuedPdfStore } from './queued-pdfs.js';
-import { t, errorSummary } from './i18n.js';
+import { t, errorSummary, generationLimitSummary } from './i18n.js';
 import {
     fetchTokens,
     getNotebookUrl,
@@ -599,7 +599,7 @@ async function notifyJobAttention(state, error) {
         const title = (state.sourceTitle || state.notebookTitle || t('Source')).slice(0, 120);
         await chrome.notifications.create(id, {
             type: 'basic', iconUrl: 'icons/icon128.png', title: t('ScholarRelay Error'),
-            message: `${title} · ${errorSummary(error)}`, priority: 2,
+            message: `${title} · ${generationLimitSummary(state.tasks) || errorSummary(error)}`, priority: 2,
         });
     } catch (error) { console.warn('[Notification] Could not show job attention:', error); }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -455,3 +455,10 @@ The separately reported sign-in detection failure has not been confirmed fixed b
 ### v1.4.3 expedited release
 
 PRs #58, #59 and #60 merged in dependency order after their exact-head checks passed. Version 1.4.3 replaces the pending 1.4.2 submission with session discovery classification, fully shared token refreshes, durable connection holds, actionable error notifications and compact progress. The existing remote-mutation uncertainty safeguards remain unchanged. The original signed-in incident is not claimed to be reproduced or fully resolved.
+
+
+### Generation-limit feedback candidate
+
+Issue #62 preserves per-artifact RATE_LIMITED diagnostics in a localized queue-card and job-view warning. Successful artifacts remain visible. Uncertain mutations and unrelated failures do not become quota claims. No reset time, daily allowance, global queue hold, or automatic generation retry is inferred.
+
+생성 제한이 발생한 아티팩트를 대기열 카드와 작업 화면에 표시하고 완료된 결과를 유지합니다. 결과가 불확실한 요청이나 다른 오류를 할당량 소진으로 표시하지 않으며 초기화 시각이나 자동 재시도를 추가하지 않습니다. 다음 릴리스 후보이며 배포된 동작은 변경되지 않았습니다.

--- a/docs/localization/messages.json
+++ b/docs/localization/messages.json
@@ -229,5 +229,6 @@
   "Try connection": ["다시 연결", "再接続", "Intentar conexión", "Réessayer la connexion", "Verbindung versuchen", "Tentar conexão"],
   "$1/$2 ready": ["$1/$2개 완료", "$1/$2 完了", "$1/$2 listos", "$1/$2 prêts", "$1/$2 fertig", "$1/$2 prontos"],
   "Time queued": ["대기 시간", "待機時間", "Tiempo en cola", "Temps en file", "Wartezeit", "Tempo na fila"],
-  "Elapsed time": ["경과 시간", "経過時間", "Tiempo transcurrido", "Temps écoulé", "Verstrichene Zeit", "Tempo decorrido"]
+  "Elapsed time": ["경과 시간", "経過時間", "Tiempo transcurrido", "Temps écoulé", "Verstrichene Zeit", "Tempo decorrido"],
+  "Generation is limited for $1. Try again later in the existing notebook.": ["$1 생성이 제한되었습니다. 나중에 기존 노트북에서 다시 시도하세요.", "$1 の生成が制限されています。後で既存のノートブックで再試行してください。", "La generación de $1 está limitada. Inténtalo más tarde en el cuaderno existente.", "La génération de $1 est limitée. Réessayez plus tard dans le notebook existant.", "Die Erstellung von $1 ist eingeschränkt. Versuche es später im vorhandenen Notebook erneut.", "A geração de $1 está limitada. Tente novamente mais tarde no notebook existente."]
 }

--- a/i18n.js
+++ b/i18n.js
@@ -73,6 +73,14 @@ export function progressDetail(state) {
     }[state.step] || 'Work in progress...');
 }
 
+export function generationLimitSummary(tasks = []) {
+    const limited = tasks.filter(task => task.status === 'failed' &&
+        (task.code === 'RATE_LIMITED' || /^RATE_LIMITED:/.test(task.error || '')));
+    if (!limited.length) return '';
+    return t('Generation is limited for $1. Try again later in the existing notebook.',
+        [[...new Set(limited.map(task => artifactLabel(task.type)))].join(', ')]);
+}
+
 export function errorSummary(detail) {
     const text = typeof detail === 'object' ? String(detail?.message || detail?.error || '') : String(detail || '');
     const code = detail?.code || text.match(/^([A-Z_]+):/)?.[1];

--- a/popup.js
+++ b/popup.js
@@ -674,7 +674,7 @@ function renderProgress(state) {
             `<div class="step-detail">${escapeHtml(artifactLabel(task.type))} · ${escapeHtml(artifactStatusLabel(task.status))}${task.error ? `<div>${escapeHtml(task.error)}</div>` : ''}</div>`
         ).join('')}</details>`;
     }
-    bottomHtml += `<p class="handoff-note" role="status">${escapeHtml(handoffMessage(state))}</p>`;
+    if (!generationLimitSummary(state.tasks)) bottomHtml += `<p class="handoff-note" role="status">${escapeHtml(handoffMessage(state))}</p>`;
     if (state.status === 'running' && state.step === 'wait_pdf_access') {
         bottomHtml += `<button class="btn-generate" id="btn-resume-pdf">${escapeHtml(t("Allow Download & Continue"))}</button>
           <button class="btn-secondary" id="btn-fallback-file">${escapeHtml(t("Upload PDF Instead"))}</button>

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,6 @@
 import { jobHandoff, isUnfinishedJob, jobElapsedText, jobReadyCount, hasJobActivity } from './job-queue.js';
 import { DEFAULT_SETTINGS as DEFAULTS } from './settings.js';
-import { t, localizeStaticDocument, progressDetail, errorSummary, artifactLabel, artifactStatusLabel } from './i18n.js';
+import { t, localizeStaticDocument, progressDetail, errorSummary, generationLimitSummary, artifactLabel, artifactStatusLabel } from './i18n.js';
 import { inspectPaperPage } from './content.js';
 import { choosePdfTitle, choosePdfFileTitle } from './pdf-metadata.js';
 import { directDetectionMatchesTab } from './detection-policy.js';
@@ -27,6 +27,8 @@ let lastProgressSignature = null;
 let queueSnapshot = { jobs: [], paused: false };
 
 function handoffMessage(job) {
+    const limit = generationLimitSummary(job.tasks);
+    if (limit) return limit;
     if (job.status === 'queued' && queueSnapshot.serviceBlock) return t('Waiting for connection. Your paper is saved.');
     if (job.status === 'completed' && !job.tasks?.length) return t('Source imported. No artifacts requested.');
     return {
@@ -588,8 +590,7 @@ function renderNoPdf() {
     document.getElementById('btn-upload-manual').addEventListener('click', () => promptForPdfUpload(null));
 }
 
-function errorHtml(detail) {
-    const summary = errorSummary(detail);
+function errorHtml(detail, summary = errorSummary(detail)) {
     return `<div class="pipeline-error-box" role="alert">${escapeHtml(summary)}</div>
       ${detail !== summary ? `<details class="workflow-details"><summary>${escapeHtml(t("Details"))}</summary><div class="step-detail">${escapeHtml(detail)}</div></details>` : ''}`;
 }
@@ -663,7 +664,10 @@ function renderProgress(state) {
       </div>`;
     }
     if (state.status === 'error') {
-        bottomHtml += errorHtml(state.error || state.stepDetail || 'The workflow stopped.');
+        bottomHtml += errorHtml(state.error || state.stepDetail || 'The workflow stopped.', generationLimitSummary(state.tasks) || errorSummary(state.error || state.stepDetail));
+    }
+    if (state.status !== 'error' && generationLimitSummary(state.tasks)) {
+        bottomHtml += `<div class="pipeline-error-box" role="status">${escapeHtml(generationLimitSummary(state.tasks))}</div>`;
     }
     if ((state.tasks || []).length && (state.status === 'completed' || state.tasks.some(task => task.error))) {
         bottomHtml += `<details class="workflow-details"><summary>${escapeHtml(t('Artifact details'))}</summary>${state.tasks.map(task =>

--- a/scripts/review-smoke.mjs
+++ b/scripts/review-smoke.mjs
@@ -105,3 +105,41 @@ export async function compactProgressSmoke({ popup, evaluate, reload, root, orig
     await reload(popup);
     console.log('Compact progress smoke passed in seven locales: timers, counts, stable focus and height, reduced motion and no-PDF actions');
 }
+
+export async function generationLimitSmoke({ popup, evaluate, reload, root, completedState }) {
+    const { readFile, mkdir, writeFile } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const { messageKey } = await import('../i18n.js');
+    const assert = (condition, message) => { if (!condition) throw new Error(message); };
+    const out = join(root, 'dist', 'generationLimitSmoke');
+    await mkdir(out, { recursive: true });
+    for (const locale of ['en','ko','ja','es','fr','de','pt_BR']) {
+        const catalog = JSON.parse(await readFile(join(root, '_locales', locale, 'messages.json'), 'utf8'));
+        const { identifier } = await popup.call('Page.addScriptToEvaluateOnNewDocument', { source:
+            `const catalog=${JSON.stringify(catalog)}; chrome.i18n.getMessage=(key,values=[])=>catalog[key]?.message.replace(/\\$(\\d+)/g,(_,i)=>values[i-1]??'')||'';` });
+        try {
+            for (const fixture of [{ ...completedState, status: 'error', step: 'error', tasks: [{type:'audio',status:'failed',code:'RATE_LIMITED',error:'RATE_LIMITED: API limit'}]},
+ { ...completedState, status: 'completed', step: 'done', tasks: [{type:'audio',status:'failed',code:'RATE_LIMITED'}, {type:'report',status:'completed'}]}]) {
+                await evaluate(popup, `globalThis.__smoke.setFixtureState(${JSON.stringify(fixture)})`);
+                await reload(popup);
+                await evaluate(popup, `document.querySelector('[data-show]').click()`);
+                const view = await evaluate(popup, `({hint:document.querySelector('.job-hint').textContent,
+                    warning:document.querySelector('.pipeline-error-box')?.textContent||'',ready:!!document.querySelector('.completed-box'),
+                    file:!!document.querySelector('[data-pdf-file]'),permission:!!document.querySelector('[data-pdf-permission]'),
+                    active:!!document.querySelector('.job-activity.is-active'),clock:document.querySelector('[data-elapsed]').textContent,
+                    width:document.documentElement.scrollWidth})`);
+                assert(view.width <= 360, `${locale} overflow`);
+                const expected = catalog[messageKey('Generation is limited for $1. Try again later in the existing notebook.')].message.split('$1')[0];
+                assert(view.hint.includes(expected) && view.warning.includes(expected), `${locale} generation limit hidden`);
+                if (fixture.status === 'completed') assert(view.ready, `${locale} successful result hidden`);
+            }
+            if (locale === 'en' || locale === 'ko') {
+                await evaluate(popup, `document.getElementById('job-queue').scrollIntoView({block:'start'})`);
+                await popup.call('Page.bringToFront');
+                const shot = await popup.call('Page.captureScreenshot', { format: 'png', captureBeyondViewport: false });
+                await writeFile(join(out, `${locale}.png`), Buffer.from(shot.data, 'base64'));
+            }
+        } finally { await popup.call('Page.removeScriptToEvaluateOnNewDocument', { identifier }); }
+    }
+    console.log('generationLimitSmoke passed in seven locales');
+}

--- a/scripts/smoke-extension.mjs
+++ b/scripts/smoke-extension.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { localizationSmoke } from './localization-smoke.mjs';
-import { recoverySmoke, compactProgressSmoke } from './review-smoke.mjs';
+import { recoverySmoke, compactProgressSmoke, generationLimitSmoke } from './review-smoke.mjs';
 
 const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const tempRoot = await mkdtemp(join(tmpdir(), 'scholar-relay-smoke-'));
@@ -448,6 +448,7 @@ try {
   await localizationSmoke({ popup, evaluate, reload, root: sourceRoot, completedState });
   await recoverySmoke({ popup, evaluate, reload, completedState });
   await compactProgressSmoke({ popup, evaluate, reload, root: sourceRoot, origin });
+  await generationLimitSmoke({ popup, evaluate, reload, root: sourceRoot, completedState });
 
   // Exercise the real Chrome message bridge and the complete file upload client.
   await evaluate(popup, `globalThis.__smoke.setFixtureState({status:'idle'})`);

--- a/tests/background-lifecycle.test.js
+++ b/tests/background-lifecycle.test.js
@@ -107,6 +107,16 @@ function running(tasks = []) {
     stepStartedAt: new Date().toISOString(), tasks };
 }
 
+test('all-failed generation retains quota diagnostics and notifies with the affected artifact', async () => {
+  const w = await worker();
+  w.data.userSettings.notificationEnabled = true;
+  w.context.listArtifactStatuses = async () => new Map();
+  w.data.pipelineState = running([{ type: 'audio', status: 'failed', code: 'RATE_LIMITED', error: 'RATE_LIMITED: API limit' }]);
+  await w.listener({ name: runtime.PIPELINE_ALARM_NAME });
+  assert.match(w.notifications[0].message, /Generation is limited.*Audio Overview/);
+  assert.equal(w.data.pipelineState.tasks[0].code, 'RATE_LIMITED');
+});
+
 test('backend rejects no-artifact starts without creating or claiming a notebook', async () => {
   const w = await worker();
   Object.assign(w.data.userSettings, { generateAudio: false, generateInfographic: false });

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -2,12 +2,24 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { readFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
-import { messageKey, t, progressDetail, errorSummary } from '../i18n.js';
+import { messageKey, t, progressDetail, errorSummary, generationLimitSummary } from '../i18n.js';
 
 const locales = ['en', 'ko', 'ja', 'es', 'fr', 'de', 'pt_BR'];
 const rows = JSON.parse(await readFile(new URL('../docs/localization/messages.json', import.meta.url), 'utf8'));
 const catalogs = Object.fromEntries(await Promise.all(locales.map(async locale => [locale,
     JSON.parse(await readFile(new URL(`../_locales/${locale}/messages.json`, import.meta.url), 'utf8'))])));
+
+test('generation limits name only confirmed failed artifacts and retain legacy codes', () => {
+    const limited = { type: 'audio', status: 'failed', code: 'RATE_LIMITED' };
+    for (const tasks of [[limited], [limited, { type: 'report', status: 'completed' }]]) {
+        assert.match(generationLimitSummary(tasks), /limited.*Audio Overview/);
+        assert.doesNotMatch(generationLimitSummary(tasks), /Report|daily|reset|quota/);
+    }
+    assert.match(generationLimitSummary([{ ...limited, code: null, error: 'RATE_LIMITED: API limit' }]), /limited/);
+    assert.equal(generationLimitSummary([{ ...limited, status: 'uncertain' }]), '');
+    assert.equal(generationLimitSummary([{ ...limited, code: 'TRANSIENT_MUTATION_UNCERTAIN', error: 'HTTP 429' }]), '');
+    assert.equal(generationLimitSummary([{ ...limited, code: null, error: 'Storage quota exceeded' }]), '');
+});
 
 test('all seven shipped catalogs match the translation source and preserve placeholders', () => {
     execFileSync(process.execPath, ['scripts/build-locales.mjs', '--check']);


### PR DESCRIPTION
Generation-limit errors now appear on the queue card, job view, and failure notification with the affected artifacts. Partial results remain visible and original diagnostics stay available. Ambiguous transport failures do not become quota claims, and requests are not retried automatically.

Validated with 140 tests, seven-locale Chrome smoke covering all-failed and partial results, restart and exact-byte 40 MiB transfer checks, and Gitleaks/actionlint preflight. The submitted release is unchanged.

Closes #62